### PR TITLE
Utilise === au lieu de == dans les fichiers .js

### DIFF
--- a/mangaki/mangaki/static/js/autocomplete.js
+++ b/mangaki/mangaki/static/js/autocomplete.js
@@ -67,64 +67,64 @@ function loadMenuUser() {
 
 $(document).ready(function() {
   $('input.typeahead').on('typeahead:selected', function(event, selection) {
-    if (selection.description == undefined) {
-    	if (selection.work_id == undefined)
+    if (selection.description === undefined) {
+    	if (selection.work_id === undefined)
         location.href = '/u/' + selection.username ;
       else {
         $.post('/recommend/'+ selection.work_id +'/'+ selection.id, function(status) {
-          if (status == 'success') {
+          if (status === 'success') {
             $('#alert-reco').hide();
-            if($('#success-reco').css('display') == 'none')
+            if($('#success-reco').css('display') === 'none')
               $('#success-reco').show();
           }
           else {
             $('#success-reco').hide();
-            if($('#alert-reco').css('display') == 'none')
+            if($('#alert-reco').css('display') === 'none')
              $('#alert-reco').show();
-           if (category == 'anime')
+           if (category === 'anime')
              $('#alert-reco').html('Cet utilisateur a déjà vu l\'anime que vous voulez lui recommander');
            else
              $('#alert-reco').html('Cet utilisateur a déjà lu le manga que vous voulez lui recommander');
-           if (status == 'nonsense')
+           if (status === 'nonsense')
              $('#alert-reco').html('Vous ne pouvez pas vous adresser vos propres recommandations!');
-           if (status == 'double')
+           if (status === 'double')
              $('#alert-reco').html('Vous avez déjà effectué cette recommandation');
          }
        });
       }
     }
-    else if(typeof(artistID) != 'undefined') {
+    else if(typeof(artistID) !== 'undefined') {
       addPairing(artistID, selection.id);
     } else
       location.href = '/' + category + '/' + selection.id;
     $(this).val('');
   }).on('typeahead:autocompleted', function(event, selection) {
-    if (selection.description == undefined) {
-     if (selection.work_id == undefined) { location.href = '/u/' + selection.username ; }
+    if (selection.description === undefined) {
+     if (selection.work_id === undefined) { location.href = '/u/' + selection.username ; }
      else {
       $.post('/recommend/'+ selection.work_id +'/'+ selection.id,  function(status) {
-       if (status == 'success') {
+       if (status === 'success') {
          $('#alert-reco').hide();
-         if($('#success-reco').css('display') == 'none')
+         if($('#success-reco').css('display') === 'none')
           $('#success-reco').show();
        }
         else {
            $('#success-reco').hide();
-           if($('#alert-reco').css('display') == 'none')
+           if($('#alert-reco').css('display') === 'none')
             $('#alert-reco').show();
-          if (category == 'anime')
+          if (category === 'anime')
             $('#alert-reco').html('Cet utilisateur a déjà vu l\'anime que vous voulez lui recommander');
           else
             $('#alert-reco').html('Cet utilisateur a déjà lu le manga que vous voulez lui recommander');
-          if (status == 'nonsense')
+          if (status === 'nonsense')
             $('#alert-reco').html('Vous ne pouvez pas vous adresser vos propres recommandations!');
-          if (status == 'double')
+          if (status === 'double')
             $('#alert-reco').html('Vous avez déjà effectué cette recommandation');
         }
       });
     }
   }
-  else if(typeof(artistID) != 'undefined') {
+  else if(typeof(artistID) !== 'undefined') {
     addPairing(artistID, selection.id);
   } else { location.href = '/' + category + '/' + selection.id; }
   $(this).val('');

--- a/mangaki/mangaki/static/js/vote.js
+++ b/mangaki/mangaki/static/js/vote.js
@@ -5,7 +5,7 @@ var globalWorks = {
 
 function getSheet(elt) {
     entity = $(elt).closest('.data'); // See work_poster
-    if(entity.data('category') != 'dummy')
+    if(entity.data('category') !== 'dummy')
         location.href = '/' + entity.data('category') + '/' + entity.data('id');
 }
 
@@ -15,9 +15,9 @@ function vote(elt) {
     choice = $(elt).data('choice');
     pos = entity.data('pos');
     $.post('/work/' + work_id, {choice: choice}, function(rating) {
-        if(rating == '')
+        if(rating === '')
             window.location = '/user/signup';
-        if(typeof(sort_mode) != 'undefined' && sort_mode == 'mosaic' && rating)
+        if(typeof(sort_mode) !== 'undefined' && sort_mode === 'mosaic' && rating)
             loadCard(pos);
         else {
             if (rating === 'none')
@@ -37,7 +37,7 @@ function suggestion(mangaki_class) {
         'message': $('#id_message').val()
     }).success(function(data) {
         $('#alert').hide()
-        if($('#success').css('display') == 'none')
+        if($('#success').css('display') === 'none')
             $('#success').show();
         $('#success').html('Merci d\'avoir contribué à Mangaki !');
         setTimeout(function() {
@@ -46,7 +46,7 @@ function suggestion(mangaki_class) {
         }, 1000);
     }).error(function(data) {
         $('#success').hide();
-        if($('#alert').css('display') == 'none')
+        if($('#alert').css('display') === 'none')
             $('#alert').show();
         // for(line in data.responseJSON) {
         $('#alert').text(data.responseJSON['problem']);
@@ -56,7 +56,7 @@ function suggestion(mangaki_class) {
 
 function displayWork(pos, work) {
     display_votes = true;
-    if(work == undefined) {
+    if(work === undefined) {
         work = {'id': 0, 'category': 'dummy', 'title': 'Chargement…', 'poster': '/static/img/chiro.gif', 'synopsis': ''}
         display_votes = false;
     } else {
@@ -73,7 +73,7 @@ function displayWork(pos, work) {
     work_div.find('.manga-snapshot-image').hide().css('background-image', 'url(' + work['poster'] + ')').fadeIn();
     if(display_votes) {
         work_div.find('.manga-votes').fadeIn();
-        if(work['rating'] == 'willsee')
+        if(work['rating'] === 'willsee')
             work_div.find('.manga-votes a[data-choice!=willsee]').addClass('not-chosen');
     }
     else
@@ -87,7 +87,7 @@ function actuallyLoadCard(pos) {
     if (work === undefined)
         return loadCard(pos);
 
-    while (globalWorks.dejaVu.indexOf(work.id) != -1) {
+    while (globalWorks.dejaVu.indexOf(work.id) !== -1) {
         work = works.shift();
         if (work === undefined)
             return loadCard(pos);


### PR DESCRIPTION
En JavaScript, == effectue une comparaison sans prendre en compte le
type et suivant des règles alambiquées. Par exemple, `0 == ‘0’`, `0 ==
[]`, et `’0’ != []` sont tous les trois vrais en JavaScript.

Utiliser === (et !== respectivement) permet de forcer un résultat faux
si le type des valeurs comparées (par exemple un entier et une chaîne
de caractères) sont différents, et est généralement conseillé pour
diverses raisons.

Ce patch remplace dont l’utilisation de == et != par === et !==
respectivement dans le code JavaScript de Mangaki.

PR proposée après discussion avec @RaitoBezarius dans #49.