### PR TITLE
Redirige vers la page actuelle apres connexion

### DIFF
--- a/mangaki/mangaki/static/js/vote.js
+++ b/mangaki/mangaki/static/js/vote.js
@@ -15,8 +15,14 @@ function vote(elt) {
     choice = $(elt).data('choice');
     pos = entity.data('pos');
     $.post('/work/' + work_id, {choice: choice}, function(rating) {
-        if(rating === '')
-            window.location = '/user/signup';
+        if(rating === '') {
+            // FIXME: We should take the vote into account after the
+            // user signs up or logs in.
+            var next = window.location.pathname +
+                window.location.search + window.location.hash;
+            window.location.assign(
+                '/user/signup?next=' + encodeURIComponent(next));
+        }
         if(typeof(sort_mode) !== 'undefined' && sort_mode === 'mosaic' && rating)
             loadCard(pos);
         else {

--- a/mangaki/mangaki/templates/base.html
+++ b/mangaki/mangaki/templates/base.html
@@ -95,8 +95,8 @@
 
                     <ul class="nav navbar-nav navbar-right">
                     {% if not user.is_authenticated %}
-                        <li><a href="/user/login"><span class="glyphicon glyphicon-log-in"></span>&nbsp;Connexion</a></li>
-                        <li><a href="/user/signup"><span class="glyphicon glyphicon-user"></span>&nbsp;Inscription</a></li>
+                        <li><a href="/user/login/?next={{ request.get_full_path|urlencode }}"><span class="glyphicon glyphicon-log-in"></span>&nbsp;Connexion</a></li>
+                        <li><a href="/user/signup/?next={{ request.get_full_path|urlencode }}"><span class="glyphicon glyphicon-user"></span>&nbsp;Inscription</a></li>
                     {% else %}
                         <li><a href="#">Bienvenue, <strong>{{ user.username }}</strong> !</a></li>
                         <li><a href="/user/logout"><span class="glyphicon glyphicon-log-out"></span>&nbsp;Quitter</a></li>

--- a/mangaki/mangaki/templates/mangaki/anime_list.html
+++ b/mangaki/mangaki/templates/mangaki/anime_list.html
@@ -34,8 +34,8 @@
   {% else %}
   <div class=" col-md-12 col-sm-12">
     <p class="well">
-      Nouveau sur Mangaki ? <a href="/user/signup/">Inscrivez-vous</a> puis
-      <a href="/user/login/">connectez-vous</a> pour noter ces <em>anime</em>
+      Nouveau sur Mangaki ? <a href="/user/signup/?next={{ request.get_full_path|urlencode }}">Inscrivez-vous</a> puis
+      <a href="/user/login/?next={{ request.get_full_path|urlencode }}">connectez-vous</a> pour noter ces <em>anime</em>
       et obtenir des recommandations.
     </p>
   </div>

--- a/mangaki/mangaki/templates/mangaki/manga_list.html
+++ b/mangaki/mangaki/templates/mangaki/manga_list.html
@@ -32,7 +32,7 @@
 </div>
 {% else %}
 <div class=" col-md-12 col-sm-12">
-    <p class="well"> Nouveau sur Mangaki ? <a href="/user/signup/">Inscrivez-vous</a> puis <a href="/user/login/">connectez-vous</a> pour noter ces mangas et obtenir des recommandations.</p>
+    <p class="well"> Nouveau sur Mangaki ? <a href="/user/signup/?next={{ request.get_full_path|urlencode }}">Inscrivez-vous</a> puis <a href="/user/login/?next={{ request.get_full_path|urlencode }}">connectez-vous</a> pour noter ces mangas et obtenir des recommandations.</p>
 </div>
 {% endif %}
 


### PR DESCRIPTION
Actuellement, lorsqu'un utilisateur se connecte ou créé un compte, il
est redirigé vers la page d’accueil de Mangaki. Ce patch fait en sorte
qu’il soit redirigé vers la page où il était avant de se connecter à
la place.