### PR TITLE
Ajoute une page d’admin rudimentaire pour les tops

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -1,5 +1,5 @@
 # coding=utf8
-from mangaki.models import Anime, Manga, Genre, Track, OST, Artist, Studio, Editor, Rating, Page, Suggestion, SearchIssue, Announcement, Recommendation, Pairing, Reference
+from mangaki.models import Anime, Manga, Genre, Track, OST, Artist, Studio, Editor, Rating, Page, Suggestion, SearchIssue, Announcement, Recommendation, Pairing, Reference, Top, Ranking
 from django.contrib import admin
 from django.template.response import TemplateResponse
 from django.contrib.admin import helpers
@@ -216,6 +216,17 @@ class PairingAdmin(admin.ModelAdmin):
 class ReferenceAdmin(admin.ModelAdmin):
     list_display = ['work', 'url']
 
+class RankingInline(admin.TabularInline):
+    model = Ranking
+
+class TopAdmin(admin.ModelAdmin):
+    inlines = [
+        RankingInline,
+    ]
+    readonly_fields = ('category', 'date',)
+
+    def has_add_permission(self, request):
+        return False
 
 admin.site.register(Anime, AnimeAdmin)
 admin.site.register(Manga, MangaAdmin)
@@ -233,3 +244,4 @@ admin.site.register(Announcement, AnnouncementAdmin)
 admin.site.register(Recommendation, RecommendationAdmin)
 admin.site.register(Pairing, PairingAdmin)
 admin.site.register(Reference, ReferenceAdmin)
+admin.site.register(Top, TopAdmin)

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -262,9 +262,10 @@ class Top(models.Model):
     contents = models.ManyToManyField(ContentType, through='Ranking')
 
     def __str__(self):
-        return '{category} on {date}'.format(
+        return 'Top {category} on {date} (id={id})'.format(
             category=self.category,
-            date=self.date)
+            date=self.date,
+            id=self.id)
 
 class Ranking(models.Model):
     top = models.ForeignKey('Top', on_delete=models.CASCADE)


### PR DESCRIPTION
Cette page ne permet pas d'ajouter manuellement un nouveau top N (il faut le faire via `manage.py top`), mais seulement de voir la liste, de modifier les rankings, et de supprimer le top généré un certain jour en cas de besoin.