### PR TITLE
Effectue une unique requete pour les objets dans un Top

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -605,7 +605,7 @@ def top(request, category_slug):
     except Top.DoesNotExist:
         raise Http404
     data = []
-    rankings = Ranking.objects.filter(top=top)
+    rankings = Ranking.objects.filter(top=top).prefetch_related('content_object')
     for rank, ranking in enumerate(rankings):
         data.append({
             'rank': rank + 1,


### PR DESCRIPTION
Actuellement lors de l'affichage d'un Top 20, on effectue une requête par artiste. Puisque l'on sait que l'on va tous les afficher de toute facon, il vaut mieux faire une unique requête pour tous les récupérer d'un coup.