### PR TITLE
Title too long, max length 50 in template

### DIFF
--- a/mangaki/mangaki/templates/work_rating.html
+++ b/mangaki/mangaki/templates/work_rating.html
@@ -9,7 +9,7 @@
 
     {% if show_title %}
         <div class="work-snapshot-title">
-            <h4>{{ work.title }}</h4>
+            <h4 title="{{ work.title }}">{{ work.title|truncatechars:50 }}</h4>
         </div>
     {% endif %}
 </a>


### PR DESCRIPTION
Fixe une taille maximale des titres à 50 caractères dans les templates work_rating

fixes #82 