### PR TITLE
Keep the ?sort parameter when paginating

### DIFF
--- a/mangaki/mangaki/templates/pagination.html
+++ b/mangaki/mangaki/templates/pagination.html
@@ -3,19 +3,19 @@
   <ul class="pagination">
     {% if page_obj.has_previous %}
     <li>
-      <a href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+      <a href="?{% if sort_mode %}sort={{ sort_mode }}&amp;{% endif %}page={{ page_obj.previous_page_number }}" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
       </a>
     </li>
     {% endif %}
     {% for page in paginator.page_range %}
     {% if page >= page_obj.number|add:-3 and page <= page_obj.number|add:3 %}
-    <li><a href="?page={{ page }}">{% if page_obj.number == page %}<strong>{{ page }}</strong>{% else %}{{ page }}{% endif %}</a></li>
+    <li><a href="?{% if sort_mode %}sort={{ sort_mode }}&amp;{% endif %}page={{ page }}">{% if page_obj.number == page %}<strong>{{ page }}</strong>{% else %}{{ page }}{% endif %}</a></li>
     {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
     <li>
-      <a href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+      <a href="?{% if sort_mode %}sort={{ sort_mode }}&amp;{% endif %}page={{ page_obj.next_page_number }}" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
       </a>
     </li>


### PR DESCRIPTION
This is a quick fix for #124; in the long term the more appropriate
fix would probably be to keep `pagination.html` clean and instead have
a different route for each of the sort modes, e.g. `/anime/popular/`
etc.

Fixes #124.