### PR TITLE
Sélectionner toute la catégorie plutôt que son slug uniquement

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -363,7 +363,7 @@ class WorkList(WorkListMixin, ListView):
         else:
             raise Http404
 
-        queryset = queryset.only('pk', 'title', 'poster', 'nsfw', 'synopsis', 'category__slug').select_related('category__slug')
+        queryset = queryset.only('pk', 'title', 'poster', 'nsfw', 'synopsis', 'category__slug', 'category__name').select_related('category')
 
         return queryset
 


### PR DESCRIPTION
Comme on utilise le `name` d'une category dans les templates, Django avait tendance à faire des lazy load du champ `name`.

Il est préférable donc de charger en un coup toute la catégorie plutôt que seulement le `slug`.