### PR TITLE
Ajout de `by_category` dans le WorkQuerySet pour simplifier les views

### DIFF
--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -30,6 +30,12 @@ class WorkQuerySet(models.QuerySet):
             nb_dislikes__lte=RANDOM_MAX_DISLIKES,
             nb_likes__gte=F('nb_dislikes') * RANDOM_RATIO)
 
+    def by_category(self, category):
+        return self.filter(
+                category__slug=category)\
+                .select_related('category__slug')
+
+
 class Category(models.Model):
     slug = models.CharField(max_length=10, db_index=True)
     name = models.CharField(max_length=128)

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -294,7 +294,7 @@ def get_card(request, category, sort_id=1):
     chrono = Chrono(True)
     deja_vu = request.GET.get('dejavu', '').split(',')
     sort_mode = ['popularity', 'controversy', 'top', 'random'][int(sort_id) - 1]
-    queryset = Work.objects.filter(category__slug=category)
+    queryset = Work.objects.by_category(category)
     if sort_mode == 'popularity':
         queryset = queryset.popular()
     elif sort_mode == 'controversy':
@@ -306,9 +306,11 @@ def get_card(request, category, sort_id=1):
     if request.user.is_authenticated():
         rated_works = Rating.objects.filter(user=request.user).values('work_id')
         queryset = queryset.exclude(id__in=rated_works)
-    queryset = queryset[:54]
+
+    queryset = queryset.only('id', 'title', 'poster', 'nsfw', 'synopsis')[:54]
     cards = []
-    for work in queryset.values('id', 'title', 'poster', 'synopsis', 'nsfw'):
+
+    for work in queryset.values('id', 'title', 'poster', 'nsfw', 'synopsis'):
         update_poster_if_nsfw_dict(work, request.user)
         work['category'] = category
         cards.append(work)
@@ -340,7 +342,7 @@ class WorkList(WorkListMixin, ListView):
         return self.kwargs.get('category', 'anime')
 
     def get_queryset(self):
-        queryset = Work.objects.filter(category__slug=self.category())
+        queryset = Work.objects.by_category(self.category())
         sort_mode = self.request.GET.get('sort', 'mosaic')
 
         if sort_mode == 'top':
@@ -363,9 +365,7 @@ class WorkList(WorkListMixin, ListView):
         else:
             raise Http404
 
-        queryset = queryset.only('pk', 'title', 'poster', 'nsfw', 'synopsis', 'category__slug').select_related('category__slug')
-
-        return queryset
+        return queryset.only('pk', 'title', 'poster', 'nsfw', 'synopsis', 'category__slug')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Plutôt que d'appeler dans son coin, le `filter` et le `select_related`, ces opérations sont obligatoirement liés -- à moins qu'il y'ait une raison pour laquelle on voudrait filter sans sélectionner le nom / le slug de la catégorie.

Du coup, il faut répercuter ça dans `get_card` et `get_queryset`, par ailleurs, il me semble qu'on devrait avoir le même mécanisme dans `get_card`.

Et je n'ai pas compris pourquoi 54 items par appel d'API, @jilljenn si tu as une explication :D.

Cela aurait peut-être dû rentrer dans #155 en fait, mais bon, je peux gérer le merge pre/post merging de #155 ou celle-ci.