### PR TITLE
Add cookie law banner

### DIFF
--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount',
     'bootstrapform',
     'analytical',
+    'cookielaw',
     # 'django_extensions'
 )
 

--- a/mangaki/mangaki/templates/base.html
+++ b/mangaki/mangaki/templates/base.html
@@ -1,4 +1,5 @@
 {% load google_analytics %}
+{% load cookielaw_tags %}
 <!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -19,6 +20,7 @@
     <script src="/static/js/typeahead.bundle.js"></script>
     <script src="/static/js/autocomplete.js"></script>
     <script src="/static/js/tooltip.js"></script>
+    <script src="/static/cookielaw/js/cookielaw.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js"></script>
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" />
     <link rel="stylesheet" href="/static/css/bootstrap-switch.min.css" />
@@ -30,6 +32,7 @@
 </head>
 
 <body>
+    {% cookielaw_banner %}
     <header class="navbar navbar-default">
         <nav class="navbar navbar-default" role="navigation">
             <div class="container-fluid">

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ beautifulsoup4
 lxml
 natsort
 django-analytical
+django-cookie-law


### PR DESCRIPTION
C'était facile, il existe un package pour ça : https://pypi.python.org/pypi/django-cookie-law/1.0.7

Fixes #142.