### PR TITLE
Canonicalize work URLs

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -186,6 +186,13 @@ class WorkDetail(AjaxableResponseMixin, FormMixin, SingleObjectTemplateResponseM
 
         return context
 
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if self.kwargs.get('category', None) != self.object.category.slug:
+            return redirect(self.object.get_absolute_url())
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
     def post(self, request, *args, **kwargs):
         if not request.user.is_authenticated():
             return HttpResponseForbidden()


### PR DESCRIPTION
Fixes #66.

Ceci fait en sorte que `/{anime,work,manga,album}/ID` redirigent tous vers `/anime/ID` si c'est un anime, `/manga/ID` si c'est un manga, etc.
C'est une décision arbitraire pour #66 qui pourra être changé dans le futur, mais c'est pas très important en vrai.