### PR TITLE
Unhide search bar on narrow screens

### DIFF
--- a/mangaki/mangaki/static/css/typeahead.css
+++ b/mangaki/mangaki/static/css/typeahead.css
@@ -302,16 +302,6 @@ p {
   font-size: 12px;
 }
 
-/* narrow screens */
-/* -------------- */
-
-@media all and (max-width: 600px) {
-  .typeahead-demo,
-  .links-examples {
-    display: none;
-  }
-}
-
 /* Rounded avatars */
 .performer img {
   margin-bottom: 0.4em;


### PR DESCRIPTION
Fixes #143.

Not sure of the original purpose of this code. `links-examples` is used nowhere in Mangaki.