### PR TITLE
Read CSV as a matrix function instead of pandas.read_csv().as_matrix()

### DIFF
--- a/mangaki/mangaki/management/commands/compare.py
+++ b/mangaki/mangaki/management/commands/compare.py
@@ -11,7 +11,6 @@ from collections import Counter
 import numpy as np
 import random
 import csv
-# import matplotlib.pyplot as plt
 
 TEST_SIZE = 50000
 

--- a/mangaki/mangaki/management/commands/compare.py
+++ b/mangaki/mangaki/management/commands/compare.py
@@ -10,10 +10,18 @@ from mangaki.utils.values import rating_values
 from collections import Counter
 import numpy as np
 import random
-import pandas
+import csv
 # import matplotlib.pyplot as plt
 
 TEST_SIZE = 50000
+
+def read_csv_as_matrix(file_name, dtypes):
+    with open(file_name, 'r') as f:
+        matrix = np.array(list(csv.reader(f)), dtype=object)
+        for index, dtype in enumerate(dtypes):
+            matrix[:, index] = matrix[:, index].astype(dtype)
+
+        return matrix
 
 class Experiment(object):
     X = None
@@ -38,7 +46,7 @@ class Experiment(object):
 
     def make_dataset(self, PIG_ID):
         self.clean_dataset()
-        ratings = pandas.read_csv('data/ratings.csv', header=None).as_matrix()
+        ratings = read_csv_as_matrix('data/ratings.csv', [np.int32, np.int32, np.str])
         if PIG_ID:  # Let's focus on the PIG
             pig_ratings = {}
             for user_id, work_id, choice in ratings:
@@ -46,7 +54,7 @@ class Experiment(object):
                     pig_ratings[work_id] = rating_values[choice]
         self.nb_users = max(ratings[:, 0]) + 1
         self.nb_works = max(ratings[:, 1]) + 1
-        self.works = pandas.read_csv('data/works.csv', header=None).as_matrix()[:, 1]
+        self.works = read_csv_as_matrix('data/works.csv', [np.int32, np.str])[:, 1]
         train, test = train_test_split(ratings, random_state=0, test_size=TEST_SIZE)
         if PIG_ID:
             train = ratings

--- a/mangaki/mangaki/utils/svd.py
+++ b/mangaki/mangaki/utils/svd.py
@@ -52,9 +52,14 @@ class MangakiSVD(object):
             matrix[user][work] = rating
         means = np.zeros((self.nb_users,))
         for i in range(self.nb_users):
-            means[i] = np.nanmean(matrix[i])
+            count_nonzero = np.count_nonzero(matrix[i])
+
+            if count_nonzero != 0:
+                means[i] = np.sum(matrix[i]) / count_nonzero
+
             if np.isnan(means[i]):
                 means[i] = 0
+
             matrix[i][matrix[i] != 0] -= means[i]
         return matrix, means
 

--- a/mangaki/mangaki/utils/svd.py
+++ b/mangaki/mangaki/utils/svd.py
@@ -52,7 +52,7 @@ class MangakiSVD(object):
             matrix[user][work] = rating
         means = np.zeros((self.nb_users,))
         for i in range(self.nb_users):
-            means[i] = np.sum(matrix[i]) / np.sum(matrix[i] != 0)
+            means[i] = np.nanmean(matrix[i])
             if np.isnan(means[i]):
                 means[i] = 0
             matrix[i][matrix[i] != 0] -= means[i]


### PR DESCRIPTION
Thanks to @Elarnon, here is a similar `read_csv…as_matrix` replacement which is not too annoying at the same time.

We could close #197 with this, I tested multiple times the command and it works (just got a bug with divide-by-zero on the SVD algorithm, due to NaN values most likely).

I invite the Research Team to try this out and _compare_ if the RMSE / shapes are relevant vs the old version so we don't have any regression. (/ping @jilljenn @ejls @Elarnon)