### PR TITLE
Add NMF for topic extraction

### DIFF
--- a/mangaki/mangaki/management/commands/compare.py
+++ b/mangaki/mangaki/management/commands/compare.py
@@ -9,7 +9,9 @@ from mangaki.utils.als import MangakiALS
 from mangaki.utils.nmf import MangakiNMF
 from mangaki.utils.zero import MangakiZero
 from mangaki.utils.values import rating_values
+from mangaki.settings import BASE_DIR
 from collections import Counter
+import os.path
 import numpy as np
 import random
 import pandas
@@ -27,7 +29,7 @@ class Experiment(object):
     results = {}
     algos = None
     def __init__(self, PIG_ID=None):
-        self.algos = [MangakiNMF(30), MangakiALS(20), MangakiSVD(20), MangakiZero()]
+        self.algos = [MangakiALS(20), MangakiSVD(20), MangakiKNN(20), MangakiZero()]
         # self.results.setdefault('x_axis', []).append()
         self.make_dataset(PIG_ID)
         self.execute()
@@ -41,7 +43,7 @@ class Experiment(object):
 
     def make_dataset(self, PIG_ID):
         self.clean_dataset()
-        ratings = pandas.read_csv('data/ratings.csv', header=None).as_matrix()
+        ratings = pandas.read_csv(os.path.join(BASE_DIR, '../data/ratings.csv'), header=None).as_matrix()
         if PIG_ID:  # Let's focus on the PIG
             pig_ratings = {}
             for user_id, work_id, choice in ratings:
@@ -49,7 +51,7 @@ class Experiment(object):
                     pig_ratings[work_id] = rating_values[choice]
         self.nb_users = max(ratings[:, 0]) + 1
         self.nb_works = max(ratings[:, 1]) + 1
-        self.works = pandas.read_csv('data/works.csv', header=None).as_matrix()[:, 1]
+        self.works = pandas.read_csv(os.path.join(BASE_DIR, '../data/works.csv'), header=None).as_matrix()[:, 1]
         train, test = train_test_split(ratings, random_state=0, test_size=TEST_SIZE)
         if PIG_ID:
             train = ratings

--- a/mangaki/mangaki/management/commands/compare.py
+++ b/mangaki/mangaki/management/commands/compare.py
@@ -6,6 +6,8 @@ from mangaki.utils.svd import MangakiSVD
 from mangaki.utils.pca import MangakiPCA
 from mangaki.utils.knn import MangakiKNN
 from mangaki.utils.als import MangakiALS
+from mangaki.utils.nmf import MangakiNMF
+from mangaki.utils.zero import MangakiZero
 from mangaki.utils.values import rating_values
 from collections import Counter
 import numpy as np
@@ -14,6 +16,7 @@ import pandas
 # import matplotlib.pyplot as plt
 
 TEST_SIZE = 50000
+
 
 class Experiment(object):
     X = None
@@ -24,7 +27,7 @@ class Experiment(object):
     results = {}
     algos = None
     def __init__(self, PIG_ID=None):
-        self.algos = [MangakiALS(20), MangakiSVD(20), MangakiKNN()]
+        self.algos = [MangakiNMF(30), MangakiALS(20), MangakiSVD(20), MangakiZero()]
         # self.results.setdefault('x_axis', []).append()
         self.make_dataset(PIG_ID)
         self.execute()

--- a/mangaki/mangaki/utils/nmf.py
+++ b/mangaki/mangaki/utils/nmf.py
@@ -1,0 +1,54 @@
+from mangaki.utils.chrono import Chrono
+from sklearn.decomposition import NMF
+from scipy.sparse import lil_matrix
+import numpy as np
+import pandas
+
+
+class MangakiNMF(object):
+    M = None
+    W = None
+    H = None
+    def __init__(self, NB_COMPONENTS=10):
+        self.NB_COMPONENTS = NB_COMPONENTS
+        self.chrono = Chrono(True)
+        self.works = pandas.read_csv('data/works.csv', header=None).as_matrix()[:, 1]
+
+    def set_parameters(self, nb_users, nb_works):
+        self.nb_users = nb_users
+        self.nb_works = nb_works
+
+    def make_matrix(self, X, y):
+        matrix = lil_matrix((self.nb_users, self.nb_works))
+        for (user, work), rating in zip(X, y):
+            matrix[user, work] = rating
+        return matrix
+
+    def fit(self, X, y):
+        print("Computing M: (%i × %i)" % (self.nb_users, self.nb_works))
+        matrix = self.make_matrix(X, y)
+
+        model = NMF(n_components=self.NB_COMPONENTS, random_state=42)
+        self.W = model.fit_transform(matrix)
+        self.H = model.components_
+        print('Shapes', self.W.shape, self.H.shape)
+        self.M = self.W.dot(self.H)
+
+        self.chrono.save('factor matrix')
+        self.display_components()
+
+    def predict(self, X):
+        return self.M[X[:, 0].astype(np.int64), X[:, 1].astype(np.int64)]
+
+    def display_components(self):
+        for i in range(self.NB_COMPONENTS):
+            print('# Component %d:' % i, )
+            for _, title in sorted((-self.H[i][j], self.works[j]) for j in range(self.nb_works))[:10]:
+                print(title)
+            print()
+
+    def __str__(self):
+        return '[NMF]'
+
+    def get_shortname(self):
+        return 'nmf'

--- a/mangaki/mangaki/utils/nmf.py
+++ b/mangaki/mangaki/utils/nmf.py
@@ -4,6 +4,40 @@ from scipy.sparse import lil_matrix
 import numpy as np
 import pandas
 
+PIG_ID = 1124#1407 # QCTX=1434  JJ=1407  SebNL=1124
+
+explanation = {
+    0: 'FATE, URBAN FANTASY',
+    1: 'MANGA SHONEN',
+    2: 'CYBERPUNK',
+    3: 'HAREM, ROMANTIC COMEDY',
+    4: 'MECHA',
+    5: 'GHIBLI',
+    6: 'KYOANI, BEAUTIFUL ANIMATION',
+    7: 'ANOTHER WORLD, HORROR',
+    8: 'SURVIVAL',
+    9: 'TOWARDS THE SKY',
+    10: 'SEINEN',
+    11: '(bruit)',
+    12: '(bruit)',
+    13: 'BEAUX GOSSES',
+    14: 'MANGA SHONEN',
+    15: '(bruit)',
+    16: 'REFRESHING SLICE-OF-LIFE',
+    17: 'URASAWA',
+    18: 'SHAFT + KARA NO KYOUKAI',
+    19: 'CONAN',
+    20: 'SHONEN MOVIES',
+    21: 'SHONEN ATMOSPHERIQUES',
+    22: 'CLAMP ET AL.',
+    23: 'POPULAIRES',
+    24: 'APPRENTISSAGE (basket, manga, magie)',
+    25: 'HÉROÏNE FORTE',
+    26: 'FUJOSHI',
+    27: 'URBAN FANTASY',
+    29: 'SHONEN 90s',
+}
+
 
 class MangakiNMF(object):
     M = None
@@ -42,10 +76,12 @@ class MangakiNMF(object):
 
     def display_components(self):
         for i in range(self.NB_COMPONENTS):
-            print('# Component %d:' % i, )
-            for _, title in sorted((-self.H[i][j], self.works[j]) for j in range(self.nb_works))[:10]:
-                print(title)
-            print()
+            if self.W[PIG_ID][i]:
+                percentage = round(self.W[PIG_ID][i] * 100 / self.W[PIG_ID].sum(), 1)
+                print('# Composante %d : %s (%.1f %%)' % (i, explanation.get(i), percentage))
+                """for _, title in sorted((-self.H[i][j], self.works[j]) for j in range(self.nb_works))[:10]:
+                    print(title)
+                print()"""
 
     def __str__(self):
         return '[NMF]'

--- a/mangaki/mangaki/utils/svd.py
+++ b/mangaki/mangaki/utils/svd.py
@@ -2,7 +2,6 @@ from django.contrib.auth.models import User
 from mangaki.models import Rating, Work, Recommendation
 from mangaki.utils.chrono import Chrono
 from mangaki.utils.values import rating_values
-from scipy.sparse import lil_matrix
 from sklearn.utils.extmath import randomized_svd
 import numpy as np
 from django.db import connection

--- a/mangaki/mangaki/utils/values.py
+++ b/mangaki/mangaki/utils/values.py
@@ -1,2 +1,2 @@
-# rating_values = {'favorite': 4, 'like': 2, 'dislike': -2, 'neutral': 0.1, 'willsee': 0.5, 'wontsee': -0.5}
-rating_values = {'favorite': 1, 'like': 1, 'neutral': 0, 'dislike': 0, 'willsee': 0, 'wontsee': 0}  # For NMF
+rating_values = {'favorite': 4, 'like': 2, 'dislike': -2, 'neutral': 0.1, 'willsee': 0.5, 'wontsee': -0.5}
+# rating_values = {'favorite': 1, 'like': 1, 'neutral': 0, 'dislike': 0, 'willsee': 0, 'wontsee': 0}  # For NMF, do not use in production!

--- a/mangaki/mangaki/utils/values.py
+++ b/mangaki/mangaki/utils/values.py
@@ -1,1 +1,2 @@
-rating_values = {'favorite': 4, 'like': 2, 'dislike': -2, 'neutral': 0.1, 'willsee': 0.5, 'wontsee': -0.5}
+# rating_values = {'favorite': 4, 'like': 2, 'dislike': -2, 'neutral': 0.1, 'willsee': 0.5, 'wontsee': -0.5}
+rating_values = {'favorite': 1, 'like': 1, 'neutral': 0, 'dislike': 0, 'willsee': 0, 'wontsee': 0}  # For NMF


### PR DESCRIPTION
Here is the non-negative matrix factorization, directly from scikit-learn, that allows more interpretable components. By definition, it approximates a non-negative matrix, so I decided to put a rating of 1 for like/favorite and 0 for the rest. Thus, it does not consider dislikes, it just tries to put together things people like.

The corresponding error values:
[ALS] 0.436 (still the best)
[NMF] 0.530
[ZERO] 0.649
[SVD] 0.761 (worse than the dumb algorithm saying 0 all the time)
(I should remove willsee and wontsee from the test set though :D)

BTW, there is a [sparseness parameter](http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html) in the scikit-learn implementation!