### PR TITLE
Do not require discourse settings for avatar initialization

### DIFF
--- a/mangaki/mangaki/discourse.py
+++ b/mangaki/mangaki/discourse.py
@@ -3,14 +3,17 @@ from django.conf import settings
 import datetime
 
 def get_discourse_data(email):
-    client = DiscourseClient('http://meta.mangaki.fr', api_username=settings.DISCOURSE_API_USERNAME, api_key=settings.DISCOURSE_API_KEY)
-    try:
-        users = client._get('/admin/users/list/active.json?show_emails=true')
-        for user in users:
-            if user['email'] == email:
-                return {'avatar': 'http://meta.mangaki.fr' + user['avatar_template'], 'created_at': user['created_at']}
-        return {'avatar': '/static/img/unknown.png', 'created_at': datetime.datetime.now().isoformat() + 'Z'}
-    except:
-        return {'avatar': '/static/img/unknown.png', 'created_at': datetime.datetime.now().isoformat() + 'Z'}
+    if settings.HAS_DISCOURSE:
+        client = DiscourseClient('http://meta.mangaki.fr', api_username=settings.DISCOURSE_API_USERNAME, api_key=settings.DISCOURSE_API_KEY)
+        try:
+            users = client._get('/admin/users/list/active.json?show_emails=true')
+            for user in users:
+                if user['email'] == email:
+                    return {'avatar': 'http://meta.mangaki.fr' + user['avatar_template'], 'created_at': user['created_at']}
+        except:
+            pass
 
-
+    return {
+        'avatar': '/static/img/unknown.png',
+        'created_at': datetime.datetime.now().isoformat() + 'Z'
+    }

--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -154,6 +154,9 @@ if config.has_section('discourse'):
     DISCOURSE_SSO_SECRET = config.get('secrets', 'DISCOURSE_SSO_SECRET')
     DISCOURSE_API_USERNAME = config.get('discourse', 'DISCOURSE_API_USERNAME')
     DISCOURSE_API_KEY = config.get('secrets', 'DISCOURSE_API_KEY')
+    HAS_DISCOURSE = True
+else:
+    HAS_DISCOURSE = False
 
 if config.has_section('mal'):
     MAL_USER = config.get('mal', 'MAL_USER')


### PR DESCRIPTION
Local development environment shouldn't require discourse for e.g. viewing a user's profile page.
