### PR TITLE
Clean up signal handling

### DIFF
--- a/mangaki/mangaki/__init__.py
+++ b/mangaki/mangaki/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'mangaki.apps.MangakiConfig'

--- a/mangaki/mangaki/apps.py
+++ b/mangaki/mangaki/apps.py
@@ -6,4 +6,6 @@ class MangakiConfig(AppConfig):
     verbose_name = 'Mangaki'
 
     def ready(self):
+        # Ensure signal receivers decorated with `@receiver` are connected by
+        # importing the `receivers` module.
         from . import receivers

--- a/mangaki/mangaki/apps.py
+++ b/mangaki/mangaki/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class MangakiConfig(AppConfig):
+    name = 'mangaki'
+    verbose_name = 'Mangaki'
+
+    def ready(self):
+        from . import receivers

--- a/mangaki/mangaki/factories.py
+++ b/mangaki/mangaki/factories.py
@@ -1,8 +1,9 @@
 import factory
-from factory.django import DjangoModelFactory
+from factory.django import DjangoModelFactory, mute_signals
 
 from .models import Profile, Work, Category
 from django.contrib.auth.models import User
+from django.db.models.signals import post_save
 
 class ProfileFactory(DjangoModelFactory):
     class Meta:
@@ -15,12 +16,14 @@ class ProfileFactory(DjangoModelFactory):
     newsletter_ok = factory.Faker('boolean')
     avatar_url = factory.LazyAttribute(lambda o: '{}{}.png'.format(factory.Faker('url').generate({}), o.mal_username))
 
+@mute_signals(post_save)
 class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
 
     username = factory.Faker('user_name')
     email = factory.LazyAttribute(lambda o: '{}@mangaki.fr'.format(o.username))
+    profile = factory.RelatedFactory(ProfileFactory, 'user')
 
 class WorkFactory(DjangoModelFactory):
     class Meta:

--- a/mangaki/mangaki/factories.py
+++ b/mangaki/mangaki/factories.py
@@ -21,7 +21,6 @@ class UserFactory(DjangoModelFactory):
 
     username = factory.Faker('user_name')
     email = factory.LazyAttribute(lambda o: '{}@mangaki.fr'.format(o.username))
-    profile = factory.RelatedFactory(ProfileFactory, 'user')
 
 class WorkFactory(DjangoModelFactory):
     class Meta:

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -281,10 +281,9 @@ class Suggestion(models.Model):
         score = suggestions_score + recommendations_score
         Profile.objects.filter(user=self.user).update(score=score)
 
-
-def suggestion_saved(sender, instance, *args, **kwargs):
-    instance.update_scores()
-models.signals.post_save.connect(suggestion_saved, sender=Suggestion)
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.update_scores()
 
 
 class Neighborship(models.Model):

--- a/mangaki/mangaki/receivers.py
+++ b/mangaki/mangaki/receivers.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.conf import settings
+
+from mangaki.models import Profile
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.create(user=instance)

--- a/mangaki/mangaki/tests/test_user.py
+++ b/mangaki/mangaki/tests/test_user.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from mangaki.models import Profile
+
+
+class UserTest(TestCase):
+    def setUp(self):
+        self.User = get_user_model()
+
+    def test_user_creation_creates_profile(self):
+        u = self.User.objects.create_user('testuser')
+        self.assertIsInstance(u.profile, Profile)

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -19,8 +19,6 @@ from django.views.generic.detail import SingleObjectMixin
 from django.dispatch import receiver
 from django.db.models import Count, Case, When, F, Value, Sum, IntegerField
 from django.db import connection
-from allauth.account.signals import user_signed_up
-from allauth.socialaccount.signals import social_account_added
 from mangaki.models import Work, Rating, Page, Profile, Artist, Suggestion, SearchIssue, Announcement, Recommendation, Pairing, Top, Ranking, Staff, Category, FAQTheme
 from mangaki.mixins import AjaxableResponseMixin, JSONResponseMixin
 from mangaki.mixins import AjaxableResponseMixin
@@ -694,13 +692,6 @@ def add_pairing(request, artist_id, work_id):
         work = get_object_or_404(Work, id=work_id)
         Pairing(user=request.user, artist=artist, work=work).save()
     return HttpResponse()
-
-
-@receiver(user_signed_up)
-@receiver(social_account_added)
-def register_profile(sender, **kwargs):
-    user = kwargs['user']
-    Profile(user=user).save()
 
 
 def faq_index(request):


### PR DESCRIPTION
 - We no longer use a post_save signal for updating scores when a Suggestion is
   changed; rather this has its place directly in the Suggestion.save method.
 - Signals are connected in the ready() method of Mangaki's new application
   configuration class, as recommended by Django's documentation:
   https://docs.djangoproject.com/en/dev/topics/signals/#connecting-receiver-functions
   Note that we use a receivers module instead of a signals module to allow for
   the creation and import of custom signals without registering handlers if
   the need ever arises.
 - Profile creation is no longer tied to login with django-allauth but rather
   to the actual User model creation. This helps handling corner cases such as
   accounts created through the `manage.py createsuperuser` management command
   actually having a profile.
