### PR TITLE
Fix CodeCov UI when browsing files coverage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,5 +34,7 @@ test:
       --with-xunit
       --xunit-file=$CIRCLE_TEST_REPORTS/nosetests.xml
       --cover-package=mangaki,irl,discourse
+    - cd ..
   post:
+    # CodeCov MUST absolutely run in the project root folder
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
CodeCov tool must run in the project root folder in order for the website UI to work.

Yes, it's strange, but we have to comply.