### PR TITLE
Move Pandas, sklearn, SciPy to production requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,9 +3,6 @@
 django-debug-toolbar==1.6
 django-extensions
 django-nose
-pandas
-scipy
-scikit-learn==0.18.*
 tensorflow
 matplotlib
 flake8

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,3 +10,6 @@ natsort
 django-analytical
 django-cookie-law
 django-js-reverse
+scikit-learn==0.18.*
+scipy
+pandas


### PR DESCRIPTION
Due to DPP recent introduction on `master`.