### PR TITLE
Fix path of pickle files (broken so far)

### DIFF
--- a/mangaki/mangaki/tests/test_reco.py
+++ b/mangaki/mangaki/tests/test_reco.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
+
+
+class RecoTest(TestCase):
+
+    def setUp(self):
+        User.objects.create_user(username='test', password='test')
+
+    def test_reco(self, **kwargs):
+        self.client.login(username='test', password='test')
+        reco_url = reverse('get-reco-algo-list', args=['svd', 'all'])
+        self.assertEqual(reco_url, '/data/reco/svd/all.json')

--- a/mangaki/mangaki/tests/test_user.py
+++ b/mangaki/mangaki/tests/test_user.py
@@ -5,6 +5,7 @@ from mangaki.models import Profile
 
 
 class UserTest(TestCase):
+    
     def setUp(self):
         self.User = get_user_model()
 

--- a/mangaki/mangaki/utils/algo.py
+++ b/mangaki/mangaki/utils/algo.py
@@ -20,7 +20,7 @@ def fit_algo(algo_name, queryset, backup_filename):
     anonymized = dataset.make_anonymous_data(queryset)
     algo.set_parameters(anonymized.nb_users, anonymized.nb_works)
     algo.fit(anonymized.X, anonymized.y)
-    if algo_name in {'svd', 'als', 'wals'}:  # KNN is constantly refreshed
+    if algo_name in {'svd', 'als'}:  # KNN is constantly refreshed
         algo.save(backup_filename)
         dataset.save('ratings-' + backup_filename)
     return dataset, algo

--- a/mangaki/mangaki/utils/common.py
+++ b/mangaki/mangaki/utils/common.py
@@ -13,12 +13,20 @@ class RecommendationAlgorithm:
         self.nb_users = None
         self.nb_works = None
 
+    def get_backup_path(self, filename):
+        return os.path.join(PICKLE_DIR, self.get_backup_filename())
+
+    def has_backup(self, filename=None):
+        if filename is None:
+            filename = self.get_backup_filename()
+        return os.path.isfile(self.get_backup_path(filename))
+
     def save(self, filename):
-        with open(os.path.join(PICKLE_DIR, filename), 'wb') as f:
+        with open(self.get_backup_path(filename), 'wb') as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 
     def load(self, filename):
-        with open(os.path.join(PICKLE_DIR, filename), 'rb') as f:
+        with open(self.get_backup_path(filename), 'rb') as f:
             backup = pickle.load(f)
         return backup
 
@@ -28,6 +36,9 @@ class RecommendationAlgorithm:
 
     def get_shortname(self):
         return 'algo'
+
+    def get_backup_filename(self):
+        return '%s.pickle' % self.get_shortname()
 
     def __str__(self):
         return '[%s]' % self.get_shortname().upper()

--- a/mangaki/mangaki/utils/common.py
+++ b/mangaki/mangaki/utils/common.py
@@ -14,7 +14,9 @@ class RecommendationAlgorithm:
         self.nb_works = None
 
     def get_backup_path(self, filename):
-        return os.path.join(PICKLE_DIR, self.get_backup_filename())
+        if filename is None:
+            filename = self.get_backup_filename()
+        return os.path.join(PICKLE_DIR, filename)
 
     def has_backup(self, filename=None):
         if filename is None:

--- a/mangaki/mangaki/utils/data.py
+++ b/mangaki/mangaki/utils/data.py
@@ -3,6 +3,7 @@ import pickle
 import random
 from collections import Counter, namedtuple
 from mangaki.utils.values import rating_values
+from mangaki.utils.common import PICKLE_DIR
 import numpy as np
 from datetime import datetime
 
@@ -24,11 +25,11 @@ class Dataset:
         self.datetime = datetime.now()
 
     def save(self, filename):
-        with open(os.path.join('pickles', filename), 'wb') as f:
+        with open(os.path.join(PICKLE_DIR, filename), 'wb') as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 
     def load(self, filename):
-        with open(os.path.join('pickles', filename), 'rb') as f:
+        with open(os.path.join(PICKLE_DIR, filename), 'rb') as f:
             backup = pickle.load(f)
         self.anonymized = backup.anonymized
         self.encode_user = backup.encode_user

--- a/mangaki/mangaki/utils/recommendations.py
+++ b/mangaki/mangaki/utils/recommendations.py
@@ -15,7 +15,7 @@ CHRONO_ENABLED = True
 
 
 def get_reco_algo(user, algo_name='knn', category='all'):
-    chrono = Chrono(is_enabled=CHRONO_ENABLED, connection=connection)
+    chrono = Chrono(is_enabled=CHRONO_ENABLED)
 
     already_rated_works = Rating.objects.filter(user=user).values_list('work_id', flat=True)
 
@@ -48,13 +48,12 @@ def get_reco_algo(user, algo_name='knn', category='all'):
     chrono.save('get all %d interesting ratings' % queryset.count())
 
     dataset = Dataset()
-    backup_filename = '%s.pickle' % algo_name
-    if os.path.isfile(os.path.join('pickles', backup_filename)):  # When Algo class will be there: 'if algo.has_backup():'
-        algo = ALGOS[algo_name]()
-        algo.load(backup_filename)
-        dataset.load('ratings-' + backup_filename)
+    algo = ALGOS[algo_name]()
+    if algo.has_backup():
+        algo.load(algo.get_backup_filename())
+        dataset.load('ratings-' + algo.get_backup_filename())
     else:
-        dataset, algo = fit_algo(algo_name, queryset, backup_filename)
+        dataset, algo = fit_algo(algo_name, queryset, algo.get_backup_filename())
 
     chrono.save('fit %s' % algo.get_shortname())
 

--- a/mangaki/mangaki/utils/wals.py
+++ b/mangaki/mangaki/utils/wals.py
@@ -34,8 +34,7 @@ class MangakiWALS(RecommendationAlgorithm):
         self.sess = tf.InteractiveSession()
 
     def load(self, filename):
-        with open(os.path.join('pickles', filename), 'rb') as f:
-            backup = pickle.load(f)
+        backup = super().load(filename)
         self.M = backup.M
         self.U = backup.U
         self.VT = backup.VT


### PR DESCRIPTION
Dans la foulée j'ai vraiment cru que je pourrais faire un test de la route recommandation mais c'est galère parce qu'il faut :

- ajouter des œuvres bidon pour les recommandations, avec leurs ratings
- gérer le cas où un objet Pickle est déjà enregistré ou pas

En plus du coup ça va ralentir les tests. Notez qu'on peut juste tester MangakiZero, mais faut quand même les œuvres bidon.