### PR TITLE
Enable anonymous users to get recommendations

### DIFF
--- a/mangaki/mangaki/management/commands/fit_algo.py
+++ b/mangaki/mangaki/management/commands/fit_algo.py
@@ -13,6 +13,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         algo_name = options.get('algo_name')
         backup_filename = '%s.pickle' % algo_name
-        queryset = Rating.objects.all()
-        fit_algo(algo_name, queryset, backup_filename)
+        triplets = Rating.objects.values_list('user_id', 'work_id', 'choice')
+        fit_algo(algo_name, triplets, backup_filename)
         self.stdout.write(self.style.SUCCESS('Successfully fit %s' % algo_name))

--- a/mangaki/mangaki/templates/base.html
+++ b/mangaki/mangaki/templates/base.html
@@ -70,13 +70,11 @@
                                 Mangas
                             </a>
                         </li>
-                    {% if user.is_authenticated %}
                         <li class="dropdown">
                             <a href="{% url 'reco' %}">
                                 Recommandations
                             </a>
                         </li>
-                    {% endif %}
                         <li class="dropdown">
                             <a href="{% url 'events' %}">
                                 Événements

--- a/mangaki/mangaki/utils/algo.py
+++ b/mangaki/mangaki/utils/algo.py
@@ -13,11 +13,11 @@ ALGOS = {
 }
 
 
-def fit_algo(algo_name, queryset, backup_filename):
+def fit_algo(algo_name, triplets, backup_filename):
     algo = ALGOS[algo_name]()
     dataset = Dataset()
 
-    anonymized = dataset.make_anonymous_data(queryset)
+    anonymized = dataset.make_anonymous_data(triplets)
     algo.set_parameters(anonymized.nb_users, anonymized.nb_works)
     algo.fit(anonymized.X, anonymized.y)
     if algo_name in {'svd', 'als', 'wals'}:  # KNN is constantly refreshed

--- a/mangaki/mangaki/utils/data.py
+++ b/mangaki/mangaki/utils/data.py
@@ -37,17 +37,16 @@ class Dataset:
         self.decode_work = backup.decode_work
         self.interesting_works = backup.interesting_works
 
-    def make_anonymous_data(self, queryset):
-        triplets = []
+    def make_anonymous_data(self, triplets):
+        triplets = list(triplets)
         users = set()
         works = set()
         nb_ratings = Counter()
         X = []
         y = []
-        for user_id, work_id, rating in queryset.values_list('user_id', 'work_id', 'choice'):
+        for user_id, work_id, rating in triplets:
             users.add(user_id)
             works.add(work_id)
-            triplets.append((user_id, work_id, rating))
             nb_ratings[work_id] += 1
         random.shuffle(triplets)  # Scramble time
 

--- a/mangaki/mangaki/utils/ratings.py
+++ b/mangaki/mangaki/utils/ratings.py
@@ -1,0 +1,146 @@
+from mangaki.models import Recommendation, Rating, Profile
+from django.conf import settings
+
+
+def pk_from_object_or_pk(obj):
+    return getattr(obj, 'pk', obj)
+
+
+def current_user_ratings(request, works=None):
+    """
+    Compute the set of ratings for the current user.
+
+    This handles both the case where the user is logged in and the case where
+    it is an anonymous user, in which case the rating is fetched from the
+    session.
+
+    If the `works` argument is given, then only the ratings for the given works
+    will be considered.
+
+    Arguments:
+        request -- The Request object we are currently handling.
+        works   -- An iterable of Work instances or primary keys, or None.
+
+    Returns:
+        ratings -- A dictionary mapping Work primary keys to their rating
+            string ('like', 'dislike', etc.)
+    """
+    user = request.user
+    if user.is_anonymous:
+        ratings = request.session.get(settings.ANONYMOUS_RATINGS_SESSION_KEY, {})
+        if works is not None:
+            filtered_ratings = {}
+            for work in works:
+                # Accept Work models as well as primary key integers
+                work = str(pk_from_object_or_pk(work))
+                rating = ratings.get(work)
+                if rating is not None:
+                    filtered_ratings[work] = rating
+            ratings = filtered_ratings
+        # Recall that keys in the session dictionary are always converted to
+        # strings by serialization. We convert them back to integers.
+        return {int(work_pk): choice for work_pk, choice in ratings.items()}
+
+    else:
+        qs = user.rating_set.all()
+        if works is not None:
+            qs = qs.filter(work__in=works)
+        return dict(qs.values_list('work_id', 'choice'))
+
+
+def current_user_rating(request, work):
+    """
+    Get the rating the current user gave to a specific work.
+
+    This handles both the case where the user is logged in and the case where
+    it is an anonymous user, in which case the rating is fetched from the
+    session.
+
+    Note: If the ratings for several different works are needed, you should use
+    the `current_user_ratings` function directly instead.
+
+    Arguments:
+        request -- The Request object we are currently handling.
+        work    -- A Work object or primary key for which the rating is
+            required.
+
+    Returns:
+        rating -- The rating that the current user gave to the work, or None if
+            there is no such rating.
+    """
+    work = int(pk_from_object_or_pk(work))
+    return current_user_ratings(request, [work]).get(work)
+
+
+def current_user_set_toggle_rating(request, work, choice):
+    """
+    Update the rating the current user gave to a specific work.
+
+    As this function's name indicated, if the user already rated the work with
+    the same choice, this will undo (toggle) this rating instead of being a
+    no-op. This corresponds to Mangaki's current UI where clicking again on an
+    existing rating will un-rate the work.
+
+    Arguments:
+        request -- The Request object we are currently handling.
+        work    -- The Work object (or its primary key) that we are currently
+            rating.
+        choice  -- The rating we want to assign (or remove) from the work.
+
+    Returns:
+        choice -- The new rating associated with the work for the current user.
+            In case an existing rating was removed, this will be None instead.
+    """
+    user = request.user
+    if user.is_authenticated:
+        old_ratings = user.rating_set.filter(work=work, choice=choice)
+        if old_ratings:
+            # FIXME: Get rid of this.
+            update_score_while_unrating(user, work, choice)
+            return None
+        else:
+            # FIXME: Get rid of this.
+            update_score_while_rating(user, work, choice)
+            user.rating_set.update_or_create(work=work, defaults={'choice': choice})
+            return choice
+    else:
+        request.session.modified = True
+        # Recall that keys in the session dictionary are always converted to
+        # strings by serialization.
+        work = str(pk_from_object_or_pk(work))
+        ratings_dict = request.session.setdefault(
+            settings.ANONYMOUS_RATINGS_SESSION_KEY, {})
+        current_rating = ratings_dict.get(work)
+        if current_rating == choice:
+            del ratings_dict[work]
+            return None
+        else:
+            ratings_dict[work] = choice
+            return choice
+
+
+def update_score_while_rating(user, work, choice):
+    recommendations_list = Recommendation.objects.filter(target_user=user, work=work)
+    for reco in recommendations_list:
+        if choice == 'like':
+            reco.user.profile.score += 1
+        elif choice == 'favorite':
+            reco.user.profile.score += 5
+        if Rating.objects.filter(user=user, work=work, choice='like').count() > 0:
+            reco.user.profile.score -= 1
+        if Rating.objects.filter(user=user, work=work, choice='favorite').count() > 0:
+            reco.user.profile.score -= 5
+        Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
+
+
+def update_score_while_unrating(user, work, choice):
+    recommendations_list = Recommendation.objects.filter(target_user=user, work=work)
+    for reco in recommendations_list:
+        if choice == 'like':
+            reco.user.profile.score -= 1
+            Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
+        elif choice == 'favorite':
+            reco.user.profile.score -= 5
+            Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
+
+

--- a/mangaki/mangaki/utils/recommendations.py
+++ b/mangaki/mangaki/utils/recommendations.py
@@ -5,6 +5,7 @@ from mangaki.utils.data import Dataset
 from django.contrib.auth.models import User
 from django.db.models import Count
 from mangaki.utils.algo import ALGOS, fit_algo
+from mangaki.utils.ratings import current_user_ratings
 import numpy as np
 import json
 import os.path
@@ -14,17 +15,33 @@ NB_RECO = 10
 CHRONO_ENABLED = True
 
 
-def get_reco_algo(user, algo_name='knn', category='all'):
-    chrono = Chrono(is_enabled=CHRONO_ENABLED, connection=connection)
-
-    already_rated_works = Rating.objects.filter(user=user).values_list('work_id', flat=True)
+def get_reco_algo(request, algo_name='knn', category='all'):
+    chrono = Chrono(is_enabled=CHRONO_ENABLED)
+    already_rated_works = list(current_user_ratings(request))
+    if request.user.is_anonymous:
+        current_user_id = 0
+        # We only support KNN for anonymous users, since the offline models did
+        # not learn anything about them.
+        # FIXME: We should also force KNN for new users for which we have no
+        # offline trained model available.
+        algo_name = 'knn'
+    else:
+        current_user_id = request.user.id
 
     chrono.save('get rated works')
 
     if algo_name == 'knn':
         queryset = Rating.objects.filter(work__in=already_rated_works)
         dataset = Dataset()
-        anonymized = dataset.make_anonymous_data(queryset)
+        triplets = list(
+            queryset.values_list('user_id', 'work_id', 'choice'))
+        if request.user.is_anonymous:
+            triplets.extend([
+                (current_user_id, work_id, choice)
+                for work_id, choice in current_user_ratings(request).items()
+            ])
+
+        anonymized = dataset.make_anonymous_data(triplets)
 
         chrono.save('make first anonymous data')
 
@@ -34,18 +51,30 @@ def get_reco_algo(user, algo_name='knn', category='all'):
 
         chrono.save('prepare first fit')
 
-        encoded_neighbors = algo.get_neighbors([dataset.encode_user[user.id]])
+        encoded_neighbors = algo.get_neighbors([dataset.encode_user[current_user_id]])
         neighbors = dataset.decode_users(encoded_neighbors[0])  # We only want for the first user
 
         chrono.save('get neighbors')
 
         # Only keep useful ratings for recommendation
-        queryset = Rating.objects.filter(user__id__in=neighbors + [user.id]).exclude(choice__in=['willsee', 'wontsee'])
+        triplets = list(
+            Rating.objects
+                  .filter(user__id__in=neighbors + [current_user_id])
+                  .exclude(choice__in=['willsee', 'wontsee'])
+                  .values_list('user_id', 'work_id', 'choice')
+        )
+        if request.user.is_anonymous:
+            triplets.extend([
+                (current_user_id, work_id, choice)
+                for work_id, choice in current_user_ratings(request).items()
+                if choice not in ('willsee', 'wontsee')
+            ])
     else:
         # Every rating is useful
-        queryset = Rating.objects.all()
+        triplets = list(
+            Rating.objects.values_list('user_id', 'work_id', 'choice'))
 
-    chrono.save('get all %d interesting ratings' % queryset.count())
+    chrono.save('get all %d interesting ratings' % len(triplets))
 
     dataset = Dataset()
     backup_filename = '%s.pickle' % algo_name
@@ -54,7 +83,7 @@ def get_reco_algo(user, algo_name='knn', category='all'):
         algo.load(backup_filename)
         dataset.load('ratings-' + backup_filename)
     else:
-        dataset, algo = fit_algo(algo_name, queryset, backup_filename)
+        dataset, algo = fit_algo(algo_name, triplets, backup_filename)
 
     chrono.save('fit %s' % algo.get_shortname())
 
@@ -69,7 +98,7 @@ def get_reco_algo(user, algo_name='knn', category='all'):
 
     chrono.save('remove already rated')
 
-    encoded_request_user_id = dataset.encode_user[user.id]
+    encoded_request_user_id = dataset.encode_user[current_user_id]
     X_test = np.asarray([[encoded_request_user_id, encoded_work_id] for encoded_work_id in encoded_works])
     y_pred = algo.predict(X_test)
     pos = y_pred.argsort()[-NB_RECO:][::-1]  # Get top NB_RECO work indices in decreasing value

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -18,12 +18,14 @@ from django.utils.functional import cached_property
 from django.db.models import Case, When, Value, Sum, IntegerField
 from django.views.generic.detail import SingleObjectMixin
 from django.db import connection, DatabaseError
-from django.conf import settings
 
 from mangaki.models import Work, Rating, ColdStartRating, Page, Profile, Artist, Suggestion, Recommendation, Pairing, Top, Ranking, Staff, Category, FAQTheme, Trope
 from mangaki.mixins import AjaxableResponseMixin, JSONResponseMixin
 from mangaki.forms import SuggestionForm
 from mangaki.utils.mal import import_mal
+from mangaki.utils.ratings import (
+    current_user_ratings, current_user_rating, current_user_set_toggle_rating
+)
 from mangaki.utils.recommendations import get_reco_algo
 from irl.models import Event, Partner, Attendee
 
@@ -61,144 +63,6 @@ RATING_COLORS = {
 UTA_ID = 14293
 
 GHIBLI_IDS = [2591, 8153, 2461, 53, 958, 30, 1563, 410, 60, 3315, 3177, 106]
-
-
-def current_user_ratings(request, works=None):
-    """
-    Compute the set of ratings for the current user.
-
-    This handles both the case where the user is logged in and the case where
-    it is an anonymous user, in which case the rating is fetched from the
-    session.
-
-    If the `works` argument is given, then only the ratings for the given works
-    will be considered.
-
-    Arguments:
-        request -- The Request object we are currently handling.
-        works   -- An iterable of Work instances or primary keys, or None.
-
-    Returns:
-        ratings -- A dictionary mapping Work primary keys to their rating
-            string ('like', 'dislike', etc.)
-    """
-    user = request.user
-    if user.is_anonymous:
-        ratings = request.session.get(settings.ANONYMOUS_RATINGS_SESSION_KEY, {})
-        if works is not None:
-            filtered_ratings = {}
-            for work in works:
-                # Accept Work models as well as primary key integers
-                work = str(getattr(work, 'pk', work))
-                rating = ratings.get(work)
-                if rating is not None:
-                    filtered_ratings[work] = rating
-            ratings = filtered_ratings
-        # Recall that keys in the session dictionary are always converted to
-        # strings by serialization. We convert them back to integers.
-        return {int(work_pk): choice for work_pk, choice in ratings.items()}
-
-    else:
-        qs = user.rating_set.all()
-        if works is not None:
-            qs = qs.filter(work__in=works)
-        return dict(qs.values_list('work_id', 'choice'))
-
-
-def current_user_rating(request, work):
-    """
-    Get the rating the current user gave to a specific work.
-
-    This handles both the case where the user is logged in and the case where
-    it is an anonymous user, in which case the rating is fetched from the
-    session.
-
-    Note: If the ratings for several different works are needed, you should use
-    the `current_user_ratings` function directly instead.
-
-    Arguments:
-        request -- The Request object we are currently handling.
-        work    -- A Work object or primary key for which the rating is
-            required.
-
-    Returns:
-        rating -- The rating that the current user gave to the work, or None if
-            there is no such rating.
-    """
-    work = int(getattr(work, 'pk', work))
-    return current_user_ratings(request, [work]).get(work)
-
-
-def current_user_set_toggle_rating(request, work, choice):
-    """
-    Update the rating the current user gave to a specific work.
-
-    As this function's name indicated, if the user already rated the work with
-    the same choice, this will undo (toggle) this rating instead of being a
-    no-op. This corresponds to Mangaki's current UI where clicking again on an
-    existing rating will un-rate the work.
-
-    Arguments:
-        request -- The Request object we are currently handling.
-        work    -- The Work object (or its primary key) that we are currently
-            rating.
-        choice  -- The rating we want to assign (or remove) from the work.
-
-    Returns:
-        choice -- The new rating associated with the work for the current user.
-            In case an existing rating was removed, this will be None instead.
-    """
-    user = request.user
-    if user.is_authenticated:
-        old_ratings = user.rating_set.filter(work=work, choice=choice)
-        if old_ratings:
-            # FIXME: Get rid of this.
-            update_score_while_unrating(user, work, choice)
-            return None
-        else:
-            # FIXME: Get rid of this.
-            update_score_while_rating(user, work, choice)
-            user.rating_set.update_or_create(work=work, defaults={'choice': choice})
-            return choice
-    else:
-        request.session.modified = True
-        # Recall that keys in the session dictionary are always converted to
-        # strings by serialization.
-        work = str(getattr(work, 'pk', work))
-        ratings_dict = request.session.setdefault(
-            settings.ANONYMOUS_RATINGS_SESSION_KEY, {})
-        current_rating = ratings_dict.get(work)
-        if current_rating == choice:
-            del ratings_dict[work]
-            return None
-        else:
-            ratings_dict[work] = choice
-            return choice
-
-
-def update_score_while_rating(user, work, choice):
-    recommendations_list = Recommendation.objects.filter(target_user=user, work=work)
-    for reco in recommendations_list:
-        if choice == 'like':
-            reco.user.profile.score += 1
-        elif choice == 'favorite':
-            reco.user.profile.score += 5
-        if Rating.objects.filter(user=user, work=work, choice='like').count() > 0:
-            reco.user.profile.score -= 1
-        if Rating.objects.filter(user=user, work=work, choice='favorite').count() > 0:
-            reco.user.profile.score -= 5
-        Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
-
-
-def update_score_while_unrating(user, work, choice):
-    recommendations_list = Recommendation.objects.filter(target_user=user, work=work)
-    for reco in recommendations_list:
-        if choice == 'like':
-            reco.user.profile.score -= 1
-            Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
-        elif choice == 'favorite':
-            reco.user.profile.score -= 5
-            Profile.objects.filter(user=reco.user).update(score=reco.user.profile.score)
 
 
 @method_decorator(ensure_csrf_cookie, name='dispatch')
@@ -723,10 +587,9 @@ def get_works(request, category):
     return HttpResponse(json.dumps(data), content_type='application/json')
 
 
-@login_required
 def get_reco_algo_list(request, algo, category):
     reco_list = []
-    data = get_reco_algo(request.user, algo, category)
+    data = get_reco_algo(request, algo, category)
     works = data['works']
     for work_id in data['work_ids']:
         work = works[work_id]
@@ -735,7 +598,7 @@ def get_reco_algo_list(request, algo, category):
 
 def get_reco_list_dpp(request, category):
     reco_list_dpp = []
-    data = get_reco_algo(request.user, 'knn', category)
+    data = get_reco_algo(request, 'knn', category)
     works = data['works']
     for work_id in data['work_ids']:
         work = works[work_id]
@@ -760,7 +623,6 @@ def remove_all_reco(request, targetname):
                 reco.delete()
 
 
-@login_required
 def get_reco(request):
     category = request.GET.get('category', 'all')
     algo = request.GET.get('algo', 'knn')
@@ -771,7 +633,6 @@ def get_reco(request):
     return render(request, 'mangaki/reco_list.html', {'reco_list': reco_list, 'category': category, 'algo': algo})
 
 
-@login_required
 def get_reco_dpp(request):
     category = request.GET.get('category', 'all')
     reco_list = [Work(title='Chargement…', ext_poster='/static/img/chiro.gif') for _ in range(4)]


### PR DESCRIPTION
This is a second step towards the resolution of #59. It allows
anonymous users to get recommendations (using the KNN algorithm only,
since we do not have trained models for them).

This is implemented by making the various algorithms take directly a
list or (user_id, work_id, choice) triplets instead of building those
from a queryset, as well as some glue to add the relevant triplets
from anonymous users at the interface between the database and the
algorithms themselves.