### PR TITLE
Fix performance issue when going on /u/{someone} with a lots of ratings

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -411,7 +411,11 @@ def get_profile(request, username=None):
             rating.choice = choice
             ratings.append(rating)
     else:
-        ratings = Rating.objects.filter(user__username=username).select_related('work')
+        ratings = (
+            Rating.objects
+            .filter(user__username=username)
+            .select_related('work', 'work__category')
+        )
 
     rating_list = natsorted(ratings,
                             key=lambda x: (ordering.index(x.choice), x.work.title.lower()))  # Tri par note puis nom


### PR DESCRIPTION
Too many duplicated queries were done to fetch categories during `get_profile`.