### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
-Django==1.10.*
+Django==1.11.*
 django-allauth==0.28
 markdown
 django-bootstrap3==8.2.*


### PR DESCRIPTION
Looks like we are not using any (broken things)[https://docs.djangoproject.com/en/1.11/releases/1.11/#backwards-incompatible-changes-in-1-11] in Django 1.11, although I only did a simple test with a local `runserver`.