### PR TITLE
Non-anonymous users don't have anonymous ratings

### DIFF
--- a/mangaki/mangaki/templatetags/anonymous_ratings.py
+++ b/mangaki/mangaki/templatetags/anonymous_ratings.py
@@ -7,4 +7,4 @@ register = template.Library()
 
 @register.filter()
 def has_anonymous_ratings(request):
-    return ratings.has_anonymous_ratings(request.session)
+    return request.user.is_anonymous and ratings.has_anonymous_ratings(request.session)


### PR DESCRIPTION
While we keep them until the session ends for technical reasons, they
shouldn't be shown.