### PR TITLE
Add link in profile for sorting any wishlist

### DIFF
--- a/mangaki/mangaki/templates/profile.html
+++ b/mangaki/mangaki/templates/profile.html
@@ -191,6 +191,10 @@
                             <h1>{% if category == 'anime' %}<a href="{% url 'work-list' 'anime' %}">Anime</a> à voir (ou
                                 non){% else %}<a href="{% url 'work-list' 'manga' %}">Mangas</a> à lire (ou
                                 pas){% endif %}</h1>
+                            <p class="well">✨🍰✨ Trier selon Mangaki !
+                            <a href="{% url 'profile' username %}?category={{ category }}&algo=svd">mainstream</a> /
+                            <a href="{% url 'profile' username %}?category={{ category }}&algo=als">perles</a>
+                            </p>
                             {% include "works_no_poster.html" with works=unseen_list class=category %}
                         </div>
                     {% endif %}

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -392,9 +392,9 @@ def get_profile(request, username=None):
         user = get_object_or_404(User, username=username)
     else:
         user = request.user
-        is_anonymous = not user.is_authenticated()
+        is_anonymous = not request.user.is_authenticated()
 
-    is_shared = is_anonymous or (username is None) or user.profile.is_shared
+    is_shared = is_anonymous or (username is None) or user == request.user or user.profile.is_shared
     category = request.GET.get('category', 'anime')
     algo_name = request.GET.get('algo', None)
     categories = ('anime', 'manga', 'album')


### PR DESCRIPTION
Minimal PR (+6 –2 lines) that should be merged asap.

Also fix the stupid bug: nobody can browse their own profile if private.

Raises the following question: should anyone sort any wishlist, or only theirs? Anyway, if a profile is public, it can be simulated by anyone, using a fake account, in order to see what Mangaki would recommend.