### PR TITLE
House-keeping of gitignore and dependencies

### DIFF
--- a/mangaki/.gitignore
+++ b/mangaki/.gitignore
@@ -1,3 +1,5 @@
 settings.ini
 /.eggs
 /mangaki.egg-info
+/build
+/dist

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r ./production.txt
 # General development
-django-debug-toolbar==1.6
+django-debug-toolbar==1.8
 django-extensions
 django-nose
 tensorflow


### PR DESCRIPTION
- Bump Django Debug Toolbar to 1.8, read [the changelog here](https://github.com/jazzband/django-debug-toolbar/blob/master/docs/changes.rst).
- Add `/build` and `/dist` to ignored directories when packaging Mangaki, those will appear and may mess with your search tools (e.g. `ag`) or whatever.