### PR TITLE
[Hotfix] Make posters refreshable once again (fix get_potential_poster)

### DIFF
--- a/mangaki/mangaki/tests/test_posters.py
+++ b/mangaki/mangaki/tests/test_posters.py
@@ -30,7 +30,6 @@ class PostersTest(TestCase):
                 'current': True,
                 'url': self.kiznaiver.ext_poster
             }]
-            # Set up mocks.
             mocked_search.return_value = NonCallableMock(poster=None)
             # Let the magic occur.
             posters = get_potential_posters(self.kiznaiver)
@@ -45,9 +44,7 @@ class PostersTest(TestCase):
                 'current': False,
                 'url': 'kiznaiver_mal_poster_url'
             }]
-            # Set up the mocks.
             mocked_search.return_value = NonCallableMock(poster=expected[1]['url'])
-            # Let the magic occur.
             posters = get_potential_posters(self.kiznaiver)
             # In this case, `get_potential_posters` should return a list of two posters, i.e. old external, MAL's one.
             self.assertCountEqual(posters, expected)

--- a/mangaki/mangaki/tests/test_posters.py
+++ b/mangaki/mangaki/tests/test_posters.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, NonCallableMock
 
 from django.test import TestCase
 
@@ -23,7 +23,6 @@ class PostersTest(TestCase):
             ext_poster='bRoKeN_lInK'  # That's how I feel when I see a broken poster.
         )
 
-    # We only want to abstract the MAL search implementation.
     @patch('mangaki.utils.db.client.search_work')
     def test_get_potential_posters(self, mocked_search):
         with self.subTest('When MAL returns no poster'):
@@ -32,11 +31,7 @@ class PostersTest(TestCase):
                 'url': self.kiznaiver.ext_poster
             }]
             # Set up mocks.
-            mocked_entry = MagicMock()
-            # Pay no mind to this ugliness:
-            # https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
-            type(mocked_entry).poster = PropertyMock(return_value=None)
-            mocked_search.return_value = mocked_entry
+            mocked_search.return_value = NonCallableMock(poster=None)
             # Let the magic occur.
             posters = get_potential_posters(self.kiznaiver)
             # In this case, `get_potential_posters` cannot fix the current poster.
@@ -48,13 +43,10 @@ class PostersTest(TestCase):
                 'url': self.kiznaiver.ext_poster
             }, {
                 'current': False,
-                'url': 'some_good_poster_with_waifus'
+                'url': 'kiznaiver_mal_poster_url'
             }]
             # Set up the mocks.
-            mocked_entry = MagicMock()
-            # Pay no mind to this ugliness (refer to link mentioned above for information).
-            type(mocked_entry).poster = PropertyMock(return_value=expected[1]['url'])
-            mocked_search.return_value = mocked_entry
+            mocked_search.return_value = NonCallableMock(poster=expected[1]['url'])
             # Let the magic occur.
             posters = get_potential_posters(self.kiznaiver)
             # In this case, `get_potential_posters` should return a list of two posters, i.e. old external, MAL's one.

--- a/mangaki/mangaki/tests/test_posters.py
+++ b/mangaki/mangaki/tests/test_posters.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from django.test import TestCase
+
+from mangaki.models import Editor, Studio, Work, Category
+
+from mangaki.utils.db import get_potential_posters
+
+
+class PostersTest(TestCase):
+
+    def setUp(self):
+        # FIXME: The defaults for editor and studio in Work requires those to
+        # exist, or else foreign key constraints fail.
+        Editor.objects.create(pk=1)
+        Studio.objects.create(pk=1)
+
+        anime = Category.objects.get(slug='anime')
+
+        self.kiznaiver = Work.objects.create(
+            title='Kiznaiver',
+            category=anime,
+            ext_poster='bRoKeN_lInK'  # That's how I feel when I see a broken poster.
+        )
+
+    # We only want to abstract the MAL search implementation.
+    @patch('mangaki.utils.db.client.search_work')
+    def test_get_potential_posters(self, mocked_search):
+        with self.subTest('When MAL returns no poster'):
+            expected = [{
+                'current': True,
+                'url': self.kiznaiver.ext_poster
+            }]
+            # Set up mocks.
+            mocked_entry = MagicMock()
+            # Pay no mind to this ugliness:
+            # https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+            type(mocked_entry).poster = PropertyMock(return_value=None)
+            mocked_search.return_value = mocked_entry
+            # Let the magic occur.
+            posters = get_potential_posters(self.kiznaiver)
+            # In this case, `get_potential_posters` cannot fix the current poster.
+            self.assertCountEqual(posters, expected)
+
+        with self.subTest('When MAL returns a poster'):
+            expected = [{
+                'current': True,
+                'url': self.kiznaiver.ext_poster
+            }, {
+                'current': False,
+                'url': 'some_good_poster_with_waifus'
+            }]
+            # Set up the mocks.
+            mocked_entry = MagicMock()
+            # Pay no mind to this ugliness (refer to link mentioned above for information).
+            type(mocked_entry).poster = PropertyMock(return_value=expected[1]['url'])
+            mocked_search.return_value = mocked_entry
+            # Let the magic occur.
+            posters = get_potential_posters(self.kiznaiver)
+            # In this case, `get_potential_posters` should return a list of two posters, i.e. old external, MAL's one.
+            self.assertCountEqual(posters, expected)

--- a/mangaki/mangaki/utils/db.py
+++ b/mangaki/mangaki/utils/db.py
@@ -1,9 +1,11 @@
+from typing import List
 from urllib.parse import urlparse
 
+from mangaki.models import Work
 from mangaki.utils.mal import client
 
 
-def get_potential_posters(work):
+def get_potential_posters(work: Work) -> List[str]:
     posters = []
     ext_urls = set()
     if work.int_poster:
@@ -14,16 +16,16 @@ def get_potential_posters(work):
     if work.ext_poster:
         ext_urls.add(urlparse(work.ext_poster).path)
         posters.append({
-            'current': False,
+            'current': False if work.int_poster else True,
             'url': work.ext_poster
         })
-    work = client.search_work(work.title)  # Query the poster to MAL from the title
-    if work.poster_url:
-        path = urlparse(work.poster_url).path
+    entry = client.get_entry_from_work(work)  # Ask MAL for guidance.
+    if entry.poster is not None:
+        path = urlparse(entry.poster).path
         if path not in ext_urls:
-            ext_urls.add(work.poster_url)
+            ext_urls.add(entry.poster)
             posters.append({
                 'current': False,
-                'url': work.poster_url,
+                'url': entry.poster,
             })
     return posters

--- a/mangaki/mangaki/utils/db.py
+++ b/mangaki/mangaki/utils/db.py
@@ -16,7 +16,7 @@ def get_potential_posters(work: Work) -> List[str]:
     if work.ext_poster:
         ext_urls.add(urlparse(work.ext_poster).path)
         posters.append({
-            'current': False if work.int_poster else True,
+            'current': work.int_poster is None,
             'url': work.ext_poster
         })
     entry = client.get_entry_from_work(work)  # Ask MAL for guidance.

--- a/mangaki/mangaki/utils/db.py
+++ b/mangaki/mangaki/utils/db.py
@@ -16,7 +16,7 @@ def get_potential_posters(work: Work) -> List[str]:
     if work.ext_poster:
         ext_urls.add(urlparse(work.ext_poster).path)
         posters.append({
-            'current': work.int_poster is None,
+            'current': not work.int_poster,
             'url': work.ext_poster
         })
     entry = client.get_entry_from_work(work)  # Ask MAL for guidance.

--- a/mangaki/mangaki/utils/mal.py
+++ b/mangaki/mangaki/utils/mal.py
@@ -227,6 +227,30 @@ class MALClient:
 
         return xml
 
+    def get_entry_from_work(self, work: Work) -> MALEntry:
+        """
+        Using a mangaki.models.Work to fetch the first (potential) matching MALEntry through MAL Search API.
+
+        WARNING: it is not guaranteed that MAL Search API will return the *good* work
+        (i.e. could be same series, another season, specials, movie, or yet another Japanese invention.)
+
+        Also, will fail on unsupported MALWorks (read the Enum definition to see what is supported).
+
+        :param work: The work to search from (`work.category.slug` and `work.title` will be used)
+        :type work: `mangaki.models.Work`
+        :return: the first matching entry from MAL
+        :rtype: MALEntry
+        """
+        try:
+            mal_work_type = MALWorks(work.category.slug)
+        except ValueError:
+            raise RuntimeError('Unsupported type of work for MAL: {}'.format(work.category))
+
+        return self.search_work(
+            mal_work_type,
+            work.title
+        )
+
     def search_work(self, work_type: MALWorks, query: str) -> MALEntry:
         xml = self._search_works(work_type, query)
 

--- a/mangaki/mangaki/utils/mal.py
+++ b/mangaki/mangaki/utils/mal.py
@@ -241,13 +241,8 @@ class MALClient:
         :return: the first matching entry from MAL
         :rtype: MALEntry
         """
-        try:
-            mal_work_type = MALWorks(work.category.slug)
-        except ValueError:
-            raise RuntimeError('Unsupported type of work for MAL: {}'.format(work.category))
-
         return self.search_work(
-            mal_work_type,
+            MALWorks(work.category.slug),
             work.title
         )
 


### PR DESCRIPTION
Due to the refactor of MAL introduced in #301 — `get_potential_poster` got broken (signature of `search_work` was incorrect).

This is fixed in this PR, with a test to prevent future regressions.