### PR TITLE
Do not show phantom works on mosaic (especially those are merged)

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -202,7 +202,8 @@ class CardList(JSONResponseMixin, ListView):
             raise Http404
         deja_vu = self.request.GET.get('dejavu', '').split(',')
         sort_mode = ['popularity', 'controversy', 'top', 'random', 'dpp'][int(sort_id) - 1]
-        queryset = Category.objects.get(slug=category).work_set.all()
+        category = Category.objects.get(slug=category)
+        queryset = Work.objects.filter(category=category).all()
         if sort_mode == 'popularity':
             queryset = queryset.popular()
         elif sort_mode == 'controversy':


### PR DESCRIPTION
The problem occurred when you merged works which appeared on your mosaic (in my case, on the 4th card, `sort_mode=random`).

Inexisting works were shown due to `work_set` which uses the base manager, which role is to *fetch EVERYTHING*, including what is phantom (i.e. merged works).

The fix is to use the right manager which is `objects` and not `all_objects`.