### PR TITLE
Add an AniList's API wrapper

### DIFF
--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -239,6 +239,10 @@ if config.has_section('anidb'):
     ANIDB_CLIENT = config.get('anidb', 'ANIDB_CLIENT')
     ANIDB_VERSION = config.get('anidb', 'ANIDB_VERSION')
 
+if config.has_section('anilist'):
+    ANILIST_CLIENT = config.get('anilist', 'ANILIST_CLIENT')
+    ANILIST_SECRET = config.get('anilist', 'ANILIST_SECRET')
+
 GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-63869890-1'
 
 JS_REVERSE_OUTPUT_PATH = 'mangaki/mangaki/static/js'

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -1,0 +1,28 @@
+from urllib.parse import urljoin
+
+import responses
+from django.conf import settings
+from django.test import TestCase
+
+from mangaki.wrappers.anilist import client, AniList
+
+
+class AniListTest(TestCase):
+    def setUp(self):
+        self.anilist = client
+
+    @responses.activate
+    def test_authentication(self):
+        responses.add(
+            responses.POST,
+            urljoin(AniList.BASE_URL, AniList.AUTH_PATH),
+            body='{"access_token":"OMtDiKBVBwe1CRAjge91mMuSzLFG6ChTgRx9LjhO","token_type":"Bearer","expires_in":3600,"expires":1500289907}',
+            status=200,
+            content_type='application/json'
+        )
+
+        auth = self.anilist._authenticate()
+        self.assertEqual(auth["access_token"], "OMtDiKBVBwe1CRAjge91mMuSzLFG6ChTgRx9LjhO")
+        self.assertEqual(auth["token_type"], "Bearer")
+        self.assertEqual(auth["expires_in"], 3600)
+        self.assertEqual(auth["expires"], 1500289907)

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from typing import Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+from django.utils.functional import cached_property
+
+from mangaki import settings
+from mangaki.models import Category
+
+
+def to_python_datetime(date):
+    """
+    Converts AniList's fuzzydate to Python datetime format.
+    >>> to_python_datetime('20150714')
+    datetime.datetime(2015, 7, 14, 0, 0)
+    """
+    date = date.strip()
+
+    year = int(date[0:4])
+    month = int(date[4:6])
+    day = int(date[6:8])
+
+    return datetime(year, month, day)
+
+
+class AniList:
+    BASE_URL = "https://anilist.co/api"
+    AUTH_PATH = "auth/access_token"
+
+    def __init__(self,
+                 client_id: Optional[str] = None,
+                 client_secret: Optional[str] = None):
+        if not client_id and client_secret:
+            self.is_available = False
+        else:
+            self.client_id = client_id
+            self.client_secret = client_secret
+            self._cache = {}
+            self._auth = None
+            self._session = requests.Session()
+            self.is_available = True
+
+    def _authenticate(self):
+        if not self.is_available:
+            raise RuntimeError('AniList API is not available!')
+
+        params = {
+            'grant_type': 'client_credentials',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }
+
+        r = self._session.post(urljoin(self.BASE_URL, self.AUTH_PATH), data=params)
+        r.raise_for_status()
+        self._auth = r.json()
+
+        return self._auth
+
+    def _request(self, datapage, params=None):
+        if not self._auth:
+            self._authenticate()
+
+        if not self.is_available:
+            raise RuntimeError('AniDB API is not available!')
+
+        if params is None:
+            params = {}
+
+    @cached_property
+    def anime_category(self) -> Category:
+        return Category.objects.get(slug='anime')
+
+client = AniList(
+    getattr(settings, 'ANILIST_CLIENT', None),
+    getattr(settings, 'ANILIST_SECRET', None)
+)

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -15,14 +15,18 @@ def to_python_datetime(date):
     Converts AniList's fuzzydate to Python datetime format.
     >>> to_python_datetime('20150714')
     datetime.datetime(2015, 7, 14, 0, 0)
+    >>> to_python_datetime('20150700')
+    datetime.datetime(2015, 7, 1, 0, 0)
+    >>> to_python_datetime('20150000')
+    datetime.datetime(2015, 1, 1, 0, 0)
     """
     date = date.strip()
-
-    year = int(date[0:4])
-    month = int(date[4:6])
-    day = int(date[6:8])
-
-    return datetime(year, month, day)
+    for fmt in ('%Y%m%d', '%Y%m00', '%Y0000'):
+        try:
+            return datetime.strptime(date, fmt)
+        except ValueError:
+            pass
+    raise ValueError('no valid date format found for {}'.format(date))
 
 
 class AniList:

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -56,7 +56,9 @@ class AniList:
 
         r = self._session.post(urljoin(self.BASE_URL, self.AUTH_PATH), data=params)
         r.raise_for_status()
+
         self._auth = r.json()
+        self._session.headers['access_token'] = self._auth['access_token']
 
         return self._auth
 
@@ -67,18 +69,18 @@ class AniList:
         if self._auth is None:
             return False
         else:
-            return self._auth["expires"] <= time.time()
-
+            return self._auth["expires"] > time.time()
 
     def _request(self, datapage, params=None):
         if not self._is_authenticated():
             self._authenticate()
 
-        if not self.is_available:
-            raise RuntimeError('AniDB API is not available!')
-
         if params is None:
             params = {}
+
+        r = requests.get(urljoin(self.BASE_URL, datapage), params=params)
+        r.raise_for_status()
+        return r
 
     @cached_property
     def anime_category(self) -> Category:

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -68,20 +68,21 @@ class AniList:
 
     def _is_authenticated(self):
         if not self.is_available:
-            raise RuntimeError('AniList API is not available!')
-
+            return False
         if self._auth is None:
             return False
-        else:
-            return self._auth["expires"] > time.time()
+        return self._auth["expires"] > time.time()
 
     def _request(self,
                  datapage: str,
-                 params: Optional[Dict[str, str]] = None):
+                 params: Optional[Dict[str, str]] = None,
+                 query_params: Optional[Dict[str, str]] = None):
         """
-        Request an Anilist API's page (see https://anilist-api.readthedocs.io/en/latest/)
-        >>> self._request("anime/{id}", {"id": "5"})
+        Request an Anilist API's page (see https://anilist-api.readthedocs.io/en/latest/ for more)
+        >>> self._request("{series_type}/{id}", params={"series_type": "anime", "id": "5"})
         Returns a series model as a JSON.
+        >>> self._request("browse/{series_type}", params={"series_type": "anime"}, query_params={"year": "2017"})
+        Returns up to 40 small series models where year is 2017 as a JSON.
         """
         if not self._is_authenticated():
             self._authenticate()
@@ -89,7 +90,10 @@ class AniList:
         if params is None:
             params = {}
 
-        r = self._session.get(urljoin(self.BASE_URL, datapage.format(**params)))
+        if query_params is None:
+            query_params = {}
+
+        r = self._session.get(urljoin(self.BASE_URL, datapage.format(**params)), params=query_params)
         r.raise_for_status()
         return r.json()
 

--- a/mangaki/settings.template.ini
+++ b/mangaki/settings.template.ini
@@ -14,19 +14,19 @@
 #  STATIC_ROOT = <base directory for static files
 
 #[hosts]
-#  ALLOWED_HOSTS = <see https://docs.djangoproject.com/fr/1.10/ref/settings/#allowed-hosts>
+#  ALLOWED_HOSTS = <see https://docs.djangoproject.com/fr/1.10/ref/settings/#allowed-hosts> 
 
 #[mal] # Used to get posters and user lists
-#  MAL_USER =
-#  MAL_USER_AGENT =
+#  MAL_USER = 
+#  MAL_USER_AGENT = 
 
 #[anidb]
-#  ANIDB_CLIENT =
+#  ANIDB_CLIENT = 
 #  ANIDB_VERSION = 1
 
 #[anilist]
-#  ANILIST_CLIENT =
-#  ANILIST_SECRET =
+#  ANILIST_CLIENT = 
+#  ANILIST_SECRET = 
 
 #[pgsql]
 #  DB_HOST = <defaults to 127.0.0.1>
@@ -37,15 +37,15 @@
 #  DSN = <sentry DSN>
 
 #[secrets]
-#  MAL_PASS =
+#  MAL_PASS = 
 
 #[smtp]
-#  EMAIL_HOST =
-#  EMAIL_HOST_PASSWORD =
-#  EMAIL_HOST_USER =
-#  EMAIL_PORT =
-#  EMAIL_SSL_CERTFILE =
-#  EMAIL_SSL_KEYFILE =
-#  EMAIL_TIMEOUT =
-#  EMAIL_USE_SSL =
-#  EMAIL_USE_TLS =
+#  EMAIL_HOST = 
+#  EMAIL_HOST_PASSWORD = 
+#  EMAIL_HOST_USER = 
+#  EMAIL_PORT = 
+#  EMAIL_SSL_CERTFILE = 
+#  EMAIL_SSL_KEYFILE = 
+#  EMAIL_TIMEOUT = 
+#  EMAIL_USE_SSL = 
+#  EMAIL_USE_TLS = 

--- a/mangaki/settings.template.ini
+++ b/mangaki/settings.template.ini
@@ -14,15 +14,19 @@
 #  STATIC_ROOT = <base directory for static files
 
 #[hosts]
-#  ALLOWED_HOSTS = <see https://docs.djangoproject.com/fr/1.10/ref/settings/#allowed-hosts> 
+#  ALLOWED_HOSTS = <see https://docs.djangoproject.com/fr/1.10/ref/settings/#allowed-hosts>
 
 #[mal] # Used to get posters and user lists
-#  MAL_USER = 
-#  MAL_USER_AGENT = 
+#  MAL_USER =
+#  MAL_USER_AGENT =
 
 #[anidb]
-#  ANIDB_CLIENT = 
+#  ANIDB_CLIENT =
 #  ANIDB_VERSION = 1
+
+#[anilist]
+#  ANILIST_CLIENT =
+#  ANILIST_SECRET =
 
 #[pgsql]
 #  DB_HOST = <defaults to 127.0.0.1>
@@ -33,15 +37,15 @@
 #  DSN = <sentry DSN>
 
 #[secrets]
-#  MAL_PASS = 
+#  MAL_PASS =
 
 #[smtp]
-#  EMAIL_HOST = 
-#  EMAIL_HOST_PASSWORD = 
-#  EMAIL_HOST_USER = 
-#  EMAIL_PORT = 
-#  EMAIL_SSL_CERTFILE = 
-#  EMAIL_SSL_KEYFILE = 
-#  EMAIL_TIMEOUT = 
-#  EMAIL_USE_SSL = 
-#  EMAIL_USE_TLS = 
+#  EMAIL_HOST =
+#  EMAIL_HOST_PASSWORD =
+#  EMAIL_HOST_USER =
+#  EMAIL_PORT =
+#  EMAIL_SSL_CERTFILE =
+#  EMAIL_SSL_KEYFILE =
+#  EMAIL_TIMEOUT =
+#  EMAIL_USE_SSL =
+#  EMAIL_USE_TLS =


### PR DESCRIPTION
Adds an API wrapper for AniList's API (see issue #343). In this PR, only basic operations are implemented :

- AniList settings in `settings.ini`
- Authenticate to AniList
- Check that the AniList's API token is still valid
- Make requests to the API