### PR TITLE
Improve tests for AniDB and AniList

### DIFF
--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from mangaki.models import Category, Editor, Studio, Work, Role, Staff, Artist, TaggedWork, Tag
-from mangaki.utils.anidb import to_python_datetime, client, AniDB
+from mangaki.utils.anidb import to_python_datetime, AniDB
 
 
 class AniDBTest(TestCase):
@@ -25,7 +25,7 @@ class AniDBTest(TestCase):
         # exist, or else foreign key constraints fail.
         Editor.objects.create(pk=1)
         # Studio.objects.create(pk=1)
-        self.anidb = client
+        self.anidb = AniDB('test_client', 1)
         self.no_anidb = AniDB()
         self.search_fixture = self.read_fixture('search_sangatsu_no_lion.xml')
         self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import os
-import doctest
 
 import responses
 from django.conf import settings
@@ -32,7 +31,10 @@ class AniDBTest(TestCase):
         self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')
 
     def test_to_python_datetime(self):
-        doctest.run_docstring_examples(to_python_datetime, globs=None)
+        self.assertEqual(to_python_datetime('2017-12-25'), datetime(2017, 12, 25, 0, 0))
+        self.assertEqual(to_python_datetime('2017-12'), datetime(2017, 12, 1, 0, 0))
+        self.assertEqual(to_python_datetime('2017'), datetime(2017, 1, 1, 0, 0))
+        self.assertRaises(ValueError, to_python_datetime, '2017-25')
 
     def test_missing_client(self):
         self.assertRaises(RuntimeError, self.no_anidb._request, 'dummypage')

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import doctest
 
 import responses
 from django.conf import settings
@@ -31,10 +32,7 @@ class AniDBTest(TestCase):
         self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')
 
     def test_to_python_datetime(self):
-        self.assertEqual(to_python_datetime('2017-12-25'), datetime(2017, 12, 25, 0, 0))
-        self.assertEqual(to_python_datetime('2017-12'), datetime(2017, 12, 1, 0, 0))
-        self.assertEqual(to_python_datetime('2017'), datetime(2017, 1, 1, 0, 0))
-        self.assertRaises(ValueError, to_python_datetime, '2017-25')
+        doctest.run_docstring_examples(to_python_datetime, globs=None)
 
     def test_missing_client(self):
         self.assertRaises(RuntimeError, self.no_anidb._request, 'dummypage')

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -26,6 +26,7 @@ class AniDBTest(TestCase):
         Editor.objects.create(pk=1)
         # Studio.objects.create(pk=1)
         self.anidb = client
+        self.no_anidb = AniDB()
         self.search_fixture = self.read_fixture('search_sangatsu_no_lion.xml')
         self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')
 
@@ -34,6 +35,10 @@ class AniDBTest(TestCase):
         self.assertEqual(to_python_datetime('2017-12'), datetime(2017, 12, 1, 0, 0))
         self.assertEqual(to_python_datetime('2017'), datetime(2017, 1, 1, 0, 0))
         self.assertRaises(ValueError, to_python_datetime, '2017-25')
+
+    def test_missing_client(self):
+        self.assertRaises(RuntimeError, self.no_anidb._request, 'dummypage')
+        self.assertFalse(self.no_anidb.is_available)
 
     @responses.activate
     def test_anidb_search(self):

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -55,97 +55,48 @@ class AniDBTest(TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
-    def test_anidb_get_multiple_animes(self):
+    def test_anidb_get_animes(self):
+        filenames = ['anidb/sangatsu_no_lion.xml', 'anidb/sangatsu_no_lion.xml', 'anidb/hibike_euphonium.xml']
         with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
-            rsps.add(
-                responses.GET,
-                AniDB.BASE_URL,
-                body=self.read_fixture('anidb/sangatsu_no_lion.xml'),
-                status=200,
-                content_type='application/xml'
-            )
-            rsps.add(
-                responses.GET,
-                AniDB.BASE_URL,
-                body=self.read_fixture('anidb/hibike_euphonium.xml'),
-                status=200,
-                content_type='application/xml'
-            )
+            for filename in filenames:
+                rsps.add(
+                    responses.GET,
+                    AniDB.BASE_URL,
+                    body=self.read_fixture(filename),
+                    status=200,
+                    content_type='application/xml'
+                )
 
             sangatsu = self.anidb.get_or_update_work(11606)
+            retrieved_tags_sangatsu = sangatsu.retrieve_tags(self.anidb)
             hibike = self.anidb.get_or_update_work(10889)
 
-        tags_sangatsu = Work.objects.get(pk=sangatsu.pk).taggedwork_set.all()
-        tags_sangatsu_titles = tags_sangatsu.values_list('tag__title', flat=True)
+        # Retrieve tags
+        tags_sangatsu = set(Work.objects.get(pk=sangatsu.pk).taggedwork_set.all().values_list('tag__title', flat=True))
+        tags_hibike = set(Work.objects.get(pk=hibike.pk).taggedwork_set.all().values_list('tag__title', flat=True))
+        shared_tags = tags_sangatsu.intersection(tags_hibike)
 
-        tags_hibike = Work.objects.get(pk=hibike.pk).taggedwork_set.all()
-        tags_hibike_titles = tags_hibike.values_list('tag__title', flat=True)
+        # Checks on tags
+        self.assertEqual(len(tags_sangatsu), 30)
+        self.assertEqual(len(tags_hibike), 38)
+        self.assertEqual(len(shared_tags), 18)
 
-        shared_tags = list(set(tags_sangatsu_titles).intersection(tags_hibike_titles))
-
+        # Check for Sangatsu's informations
         self.assertEqual(sangatsu.title, 'Sangatsu no Lion')
         self.assertEqual(sangatsu.nb_episodes, 22)
         self.assertEqual(sangatsu.studio.title, 'Shaft')
-        self.assertEqual(len(tags_sangatsu_titles), 30)
+        self.assertEqual(sangatsu.date, datetime(2016, 10, 8, 0, 0))
+        self.assertEqual(sangatsu.end_date, datetime(2017, 3, 18, 0, 0))
 
-        self.assertEqual(hibike.title, 'Hibike! Euphonium')
-        self.assertEqual(hibike.nb_episodes, 13)
-        self.assertEqual(hibike.studio.title, 'Kyoto Animation')
-        self.assertEqual(len(tags_hibike_titles), 38)
+        # Check for Sangatsu's staff
+        staff_sangatsu = Work.objects.get(pk=sangatsu.pk).staff_set.all().values_list('artist__name', flat=True)
+        self.assertCountEqual(staff_sangatsu, ['Umino Chika', 'Hashimoto Yukari', 'Shinbou Akiyuki', 'Okada Kenjirou'])
 
-        self.assertCountEqual(shared_tags, ['Japan', 'time', 'Asia', 'comedy',
-                                            'themes', 'dynamic', 'Earth', 'cast',
-                                            'hard work and guts', 'original work',
-                                            'high school', 'following one`s dream',
-                                            'elements', 'aim for the top', 'setting',
-                                            'school life', 'present', 'place'])
-
-    @responses.activate
-    def test_anidb_get(self):
-        responses.add(
-            responses.GET,
-            AniDB.BASE_URL,
-            body=self.anime_fixture,
-            status=200,
-            content_type='application/xml'
-        )
-
-        anime = self.anidb.get_or_update_work(11606)
-        retrieved_tags = anime.retrieve_tags(self.anidb)
-
-        tags = Work.objects.get(pk=anime.pk).taggedwork_set.all()
-        tag_titles = tags.values_list('tag__title', flat=True)
-
-        staff = Work.objects.get(pk=anime.pk).staff_set.all()
-        author_names = staff.filter(role__slug='author').values_list('artist__name', flat=True)
-        composer_names = staff.filter(role__slug='composer').values_list('artist__name', flat=True)
-        director_names = staff.filter(role__slug='director').values_list('artist__name', flat=True)
-
-        self.assertEqual(anime.title, 'Sangatsu no Lion')
-        self.assertEqual(anime.nb_episodes, 22)
-        self.assertEqual(anime.studio.title, 'Shaft')
-
-        self.assertEqual(anime.date, datetime(2016, 10, 8, 0, 0))
-        self.assertEqual(anime.end_date, datetime(2017, 3, 18, 0, 0))
-
-        self.assertCountEqual(author_names, ['Umino Chika'])
-        self.assertCountEqual(composer_names, ['Hashimoto Yukari'])
-        self.assertCountEqual(director_names, ['Shinbou Akiyuki', 'Okada Kenjirou'])
-
-        self.assertCountEqual(tag_titles, ['seinen', 'high school', 'dynamic', 'target audience',
-                                           'themes', 'original work', 'setting', 'elements',
-                                           'time', 'place', 'present', 'Earth', 'Japan',
-                                           'Tokyo', 'board games', 'manga', 'Asia', 'comedy',
-                                           'anthropomorphism', 'school life', 'sports',
-                                           'shougi', 'aim for the top', 'funny expressions',
-                                           'male protagonist', 'hard work and guts',
-                                           'dysfunctional family', 'following one`s dream',
-                                           'cast', 'family life'])
-
-        self.assertEqual(len(retrieved_tags["deleted_tags"]), 0)
-        self.assertEqual(len(retrieved_tags["added_tags"]), 0)
-        self.assertEqual(len(retrieved_tags["updated_tags"]), 0)
-        self.assertCountEqual(retrieved_tags["kept_tags"], tag_titles)
+        # Check retrieved tags from AniDB
+        self.assertEqual(len(retrieved_tags_sangatsu["deleted_tags"]), 0)
+        self.assertEqual(len(retrieved_tags_sangatsu["added_tags"]), 0)
+        self.assertEqual(len(retrieved_tags_sangatsu["updated_tags"]), 0)
+        self.assertEqual(len(retrieved_tags_sangatsu["kept_tags"]), len(tags_sangatsu))
 
     @responses.activate
     def test_anidb_nsfw(self):

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -56,6 +56,9 @@ class AniDBTest(TestCase):
 
     @responses.activate
     def test_anidb_get_animes(self):
+        # Fake an artist entry with no AniDB creator ID that will be filled by retrieving Sangatsu
+        artist = Artist(name="Shinbou Akiyuki").save()
+
         filenames = ['anidb/sangatsu_no_lion.xml', 'anidb/sangatsu_no_lion.xml', 'anidb/hibike_euphonium.xml']
         with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
             for filename in filenames:
@@ -97,6 +100,11 @@ class AniDBTest(TestCase):
         self.assertEqual(len(retrieved_tags_sangatsu["added_tags"]), 0)
         self.assertEqual(len(retrieved_tags_sangatsu["updated_tags"]), 0)
         self.assertEqual(len(retrieved_tags_sangatsu["kept_tags"]), len(tags_sangatsu))
+
+        # Check for no artist duplication
+        artist = Artist.objects.filter(name="Shinbou Akiyuki")
+        self.assertEqual(artist.count(), 1)
+        self.assertEqual(artist.first().anidb_creator_id, 59)
 
     @responses.activate
     def test_anidb_nsfw(self):

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from mangaki.models import Category, Editor, Studio, Work, Role, Staff, Artist, TaggedWork, Tag
-from mangaki.utils.anidb import client, AniDB
+from mangaki.utils.anidb import to_python_datetime, client, AniDB
 
 
 class AniDBTest(TestCase):
@@ -28,6 +28,12 @@ class AniDBTest(TestCase):
         self.anidb = client
         self.search_fixture = self.read_fixture('search_sangatsu_no_lion.xml')
         self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')
+
+    def test_to_python_datetime(self):
+        self.assertEqual(to_python_datetime('2017-12-25'), datetime(2017, 12, 25, 0, 0))
+        self.assertEqual(to_python_datetime('2017-12'), datetime(2017, 12, 1, 0, 0))
+        self.assertEqual(to_python_datetime('2017'), datetime(2017, 1, 1, 0, 0))
+        self.assertRaises(ValueError, to_python_datetime, '2017-25')
 
     @responses.activate
     def test_anidb_search(self):

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -11,12 +11,17 @@ from mangaki.wrappers.anilist import to_python_datetime, client, AniList
 class AniListTest(TestCase):
     def setUp(self):
         self.anilist = client
+        self.no_anilist = AniList()
 
     def test_to_python_datetime(self):
         self.assertEqual(to_python_datetime('20171225'), datetime(2017, 12, 25, 0, 0))
         self.assertEqual(to_python_datetime('20171200'), datetime(2017, 12, 1, 0, 0))
         self.assertEqual(to_python_datetime('20170000'), datetime(2017, 1, 1, 0, 0))
         self.assertRaises(ValueError, to_python_datetime, '2017')
+
+    def test_missing_client(self):
+        self.assertRaises(RuntimeError, self.no_anilist._authenticate)
+        self.assertFalse(self.no_anilist._is_authenticated())
 
     @responses.activate
     def test_authentication(self):
@@ -27,6 +32,8 @@ class AniListTest(TestCase):
             status=200,
             content_type='application/json'
         )
+        
+        self.assertFalse(self.anilist._is_authenticated())
 
         auth = self.anilist._authenticate()
         self.assertEqual(auth["access_token"], "OMtDiKBVBwe1CRAjge91mMuSzLFG6ChTgRx9LjhO")

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from urllib.parse import urljoin
+import doctest
 
 import responses
 from django.conf import settings
@@ -15,10 +16,7 @@ class AniListTest(TestCase):
         self.fake_auth_json = '{"access_token":"fake_token","token_type":"Bearer","expires_in":3600,"expires":946684800}'
 
     def test_to_python_datetime(self):
-        self.assertEqual(to_python_datetime('20171225'), datetime(2017, 12, 25, 0, 0))
-        self.assertEqual(to_python_datetime('20171200'), datetime(2017, 12, 1, 0, 0))
-        self.assertEqual(to_python_datetime('20170000'), datetime(2017, 1, 1, 0, 0))
-        self.assertRaises(ValueError, to_python_datetime, '2017')
+        doctest.run_docstring_examples(to_python_datetime, globs=None)
 
     def test_missing_client(self):
         self.assertRaises(RuntimeError, self.no_anilist._authenticate)

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -1,15 +1,22 @@
+from datetime import datetime
 from urllib.parse import urljoin
 
 import responses
 from django.conf import settings
 from django.test import TestCase
 
-from mangaki.wrappers.anilist import client, AniList
+from mangaki.wrappers.anilist import to_python_datetime, client, AniList
 
 
 class AniListTest(TestCase):
     def setUp(self):
         self.anilist = client
+
+    def test_to_python_datetime(self):
+        self.assertEqual(to_python_datetime('20171225'), datetime(2017, 12, 25, 0, 0))
+        self.assertEqual(to_python_datetime('20171200'), datetime(2017, 12, 1, 0, 0))
+        self.assertEqual(to_python_datetime('20170000'), datetime(2017, 1, 1, 0, 0))
+        self.assertRaises(ValueError, to_python_datetime, '2017')
 
     @responses.activate
     def test_authentication(self):

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -12,6 +12,7 @@ class AniListTest(TestCase):
     def setUp(self):
         self.anilist = AniList('test_client', 'client_secret')
         self.no_anilist = AniList()
+        self.fake_auth_json = '{"access_token":"fake_token","token_type":"Bearer","expires_in":3600,"expires":946684800}'
 
     def test_to_python_datetime(self):
         self.assertEqual(to_python_datetime('20171225'), datetime(2017, 12, 25, 0, 0))
@@ -28,7 +29,7 @@ class AniListTest(TestCase):
         responses.add(
             responses.POST,
             urljoin(AniList.BASE_URL, AniList.AUTH_PATH),
-            body='{"access_token":"OMtDiKBVBwe1CRAjge91mMuSzLFG6ChTgRx9LjhO","token_type":"Bearer","expires_in":3600,"expires":1500289907}',
+            body=self.fake_auth_json,
             status=200,
             content_type='application/json'
         )
@@ -36,7 +37,7 @@ class AniListTest(TestCase):
         self.assertFalse(self.anilist._is_authenticated())
 
         auth = self.anilist._authenticate()
-        self.assertEqual(auth["access_token"], "OMtDiKBVBwe1CRAjge91mMuSzLFG6ChTgRx9LjhO")
+        self.assertEqual(auth["access_token"], "fake_token")
         self.assertEqual(auth["token_type"], "Bearer")
         self.assertEqual(auth["expires_in"], 3600)
-        self.assertEqual(auth["expires"], 1500289907)
+        self.assertEqual(auth["expires"], 946684800)

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -5,12 +5,12 @@ import responses
 from django.conf import settings
 from django.test import TestCase
 
-from mangaki.wrappers.anilist import to_python_datetime, client, AniList
+from mangaki.wrappers.anilist import to_python_datetime, AniList
 
 
 class AniListTest(TestCase):
     def setUp(self):
-        self.anilist = client
+        self.anilist = AniList('test_client', 'client_secret')
         self.no_anilist = AniList()
 
     def test_to_python_datetime(self):
@@ -32,7 +32,7 @@ class AniListTest(TestCase):
             status=200,
             content_type='application/json'
         )
-        
+
         self.assertFalse(self.anilist._is_authenticated())
 
         auth = self.anilist._authenticate()

--- a/mangaki/mangaki/tests/test_anilist.py
+++ b/mangaki/mangaki/tests/test_anilist.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from urllib.parse import urljoin
-import doctest
 
 import responses
 from django.conf import settings
@@ -16,7 +15,10 @@ class AniListTest(TestCase):
         self.fake_auth_json = '{"access_token":"fake_token","token_type":"Bearer","expires_in":3600,"expires":946684800}'
 
     def test_to_python_datetime(self):
-        doctest.run_docstring_examples(to_python_datetime, globs=None)
+        self.assertEqual(to_python_datetime('20171225'), datetime(2017, 12, 25, 0, 0))
+        self.assertEqual(to_python_datetime('20171200'), datetime(2017, 12, 1, 0, 0))
+        self.assertEqual(to_python_datetime('20170000'), datetime(2017, 1, 1, 0, 0))
+        self.assertRaises(ValueError, to_python_datetime, '2017')
 
     def test_missing_client(self):
         self.assertRaises(RuntimeError, self.no_anilist._authenticate)

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -38,7 +38,7 @@ class AniDB:
     def __init__(self,
                  client_id: Optional[str] = None,
                  client_ver: Optional[int] = None):
-        if not client_id and client_ver:
+        if not client_id or not client_ver:
             self.is_available = False
         else:
             self.client_id = client_id

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -20,6 +20,10 @@ def to_python_datetime(date):
     datetime.datetime(2015, 7, 1, 0, 0)
     >>> to_python_datetime('2015')
     datetime.datetime(2015, 1, 1, 0, 0)
+    >>> to_python_datetime('2015-25')
+    Traceback (most recent call last):
+     ...
+    ValueError: no valid date format found for 2015-25
     """
     date = date.strip()
     for fmt in ('%Y-%m-%d', '%Y-%m', '%Y'):

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -36,7 +36,7 @@ class AniList:
     def __init__(self,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None):
-        if not client_id and client_secret:
+        if not client_id or not client_secret:
             self.is_available = False
         else:
             self.is_available = True

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -71,7 +71,7 @@ class AniList:
             return False
         if self._auth is None:
             return False
-        return self._auth["expires"] > time.time()
+        return self._auth['expires'] > time.time()
 
     def _request(self,
                  datapage: str,

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -19,6 +19,10 @@ def to_python_datetime(date):
     datetime.datetime(2015, 7, 1, 0, 0)
     >>> to_python_datetime('20150000')
     datetime.datetime(2015, 1, 1, 0, 0)
+    >>> to_python_datetime('2015')
+    Traceback (most recent call last):
+     ...
+    ValueError: no valid date format found for 2015
     """
     date = date.strip()
     for fmt in ('%Y%m%d', '%Y%m00', '%Y0000'):


### PR DESCRIPTION
- Fix a condition issue when checking the client availability (was `if not client_id and client_ver`)
- Test the `to_python_datetime` for both APIs
- Added a test case for when client's arguments are missing
- Use a fake client in tests (no need to use `[anidb]` or `[anilist]` settings section to test)