### PR TITLE
Handle MultipleObjectsReturned when two Works have the same AniDB AID

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -301,6 +301,7 @@ class WorkAdmin(admin.ModelAdmin):
         works = queryset.all()
 
         # Check for works with missing AniDB AID
+        offending_works = []
         if not all(work.anidb_aid for work in works):
             offending_works = [work for work in works if not work.anidb_aid]
             self.message_user(request,

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -327,11 +327,11 @@ class WorkAdmin(admin.ModelAdmin):
         refreshed = 0
         for index, work in enumerate(works, start=1):
             if work.anidb_aid and work not in works_with_conflicting_anidb_aid:
-                logging.info('Refreshing {} from AniDB.'.format(work))
+                logger.info('Refreshing {} from AniDB.'.format(work))
                 if client.get_or_update_work(work.anidb_aid) is not None:
                     refreshed += 1
                 if index % 25 == 0:
-                    logging.info('(AniDB refresh): Sleeping...')
+                    logger.info('(AniDB refresh): Sleeping...')
                     time.sleep(1)  # Don't spam AniDB.
 
         if refreshed > 0:

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -103,6 +103,23 @@ class AniDBTest(TestCase):
         self.assertEqual(artist.first().anidb_creator_id, 59)
 
     @responses.activate
+    def test_anidb_duplicate_anime_id(self):
+        for _ in range(2):
+            responses.add(
+                responses.GET,
+                AniDB.BASE_URL,
+                body=self.read_fixture('anidb/hibike_euphonium.xml'),
+                status=200,
+                content_type='application/xml'
+            )
+
+        self.create_anime(title='Hibike! Euphonium', anidb_aid=10889)
+        self.create_anime(title='Hibike! Euphonium Duplicate', anidb_aid=10889)
+
+        self.anidb.get_or_update_work(10889)
+        self.assertIs(self.anidb.get_or_update_work(10889), None)
+
+    @responses.activate
     def test_anidb_nsfw(self):
         animes = {}
 

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -30,7 +30,10 @@ class RefreshFromAniDBTest(TestCase):
 
     def setUp(self):
         self.user = get_user_model().objects.create_superuser(username='test', password='test', email='email@email.email')
-        client.__init__('test', 1)
+        
+        client.client_id = 'fake'
+        client.client_ver = 1
+        client.is_available = True
 
         self.anime = Category.objects.get(slug='anime')
         Work.objects.bulk_create([

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -32,10 +32,12 @@ class RefreshFromAniDBTest(TestCase):
         self.user = get_user_model().objects.create_superuser(username='test', password='test', email='email@email.email')
         client.__init__('test', 1)
 
-        anime = Category.objects.get(slug='anime')
+        self.anime = Category.objects.get(slug='anime')
         Work.objects.bulk_create([
-            Work(title='Hibike! Euphonium', anidb_aid=10889, category=anime),
-            Work(title='Punchline', category=anime),
+            Work(title='Hibike! Euphonium', anidb_aid=10889, category=self.anime),
+            Work(title='Punchline', category=self.anime),
+            Work(title='Kiznaiver', anidb_aid=11692, category=self.anime),
+            Work(title='Kiznaiver Duplicate', anidb_aid=11692, category=self.anime)
         ])
         self.work_ids = Work.objects.values_list('pk', flat=True)
 

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib import admin
 
 from mangaki.models import Work, Category
-from mangaki.utils.anidb import AniDB
+from mangaki.utils.anidb import AniDB, client
 
 
 class RefreshFromAniDBTest(TestCase):
@@ -30,6 +30,7 @@ class RefreshFromAniDBTest(TestCase):
 
     def setUp(self):
         self.user = get_user_model().objects.create_superuser(username='test', password='test', email='email@email.email')
+        client.__init__('test', 1)
 
         anime = Category.objects.get(slug='anime')
         Work.objects.bulk_create([

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -1,0 +1,86 @@
+import os
+
+import responses
+from django.conf import settings
+from django.test import TestCase
+
+from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
+from django.contrib import admin
+
+from mangaki.models import Work, Category
+from mangaki.utils.anidb import AniDB
+
+
+class RefreshFromAniDBTest(TestCase):
+    @staticmethod
+    def read_fixture(filename):
+        with open(os.path.join(settings.TEST_DATA_DIR, filename), 'r', encoding='utf-8') as f:
+            return f.read()
+
+    @staticmethod
+    def add_to_responses(filename):
+        responses.add(
+            responses.GET,
+            AniDB.BASE_URL,
+            body=RefreshFromAniDBTest.read_fixture('anidb/'+filename),
+            status=200,
+            content_type='application/xml'
+        )
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_superuser(username='test', password='test', email='email@email.email')
+
+        anime = Category.objects.get(slug='anime')
+        Work.objects.bulk_create([
+            Work(title='Hibike! Euphonium', anidb_aid=10889, category=anime),
+            Work(title='Punchline', category=anime),
+        ])
+        self.work_ids = Work.objects.values_list('pk', flat=True)
+
+    @responses.activate
+    def test_refresh_work_from_anidb(self):
+        self.add_to_responses('hibike_euphonium.xml')
+        self.add_to_responses('punchline.xml')
+
+        self.client.login(username='test', password='test')
+        refresh_work_from_anidb_url = reverse('admin:mangaki_work_changelist')
+        response = self.client.post(
+            refresh_work_from_anidb_url,
+            {'action': 'refresh_work_from_anidb', admin.ACTION_CHECKBOX_NAME: self.work_ids},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(Work.objects.get(anidb_aid=10889).title, 'Hibike! Euphonium')
+
+    @responses.activate
+    def test_refresh_tags_from_anidb(self):
+        self.add_to_responses('hibike_euphonium.xml')
+        self.client.login(username='test', password='test')
+
+        refresh_tags_from_anidb_url = reverse('admin:mangaki_work_changelist')
+        response = self.client.post(
+            refresh_tags_from_anidb_url,
+            {'action': 'update_tags_via_anidb', admin.ACTION_CHECKBOX_NAME: self.work_ids},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @responses.activate
+    def test_refresh_tags_from_anidb_confirmed(self):
+        self.add_to_responses('hibike_euphonium.xml')
+        self.client.login(username='test', password='test')
+
+        refresh_tags_from_anidb_url = reverse('admin:mangaki_work_changelist')
+        context = {
+            'action': 'update_tags_via_anidb',
+            admin.ACTION_CHECKBOX_NAME: self.work_ids,
+            'post': 1,
+            'checks': [Work.objects.get(title='Hibike! Euphonium').pk]
+        }
+
+        response = self.client.post(refresh_tags_from_anidb_url, context)
+        self.assertEqual(response.status_code, 302)
+
+        tags = set(Work.objects.get(anidb_aid=10889).taggedwork_set.all().values_list('tag__title', flat=True))

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
+from django.core.exceptions import MultipleObjectsReturned
 from django.utils.functional import cached_property
 from django.db.models import Q
 

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -329,9 +329,12 @@ class AniDB:
         }
 
         # Add or update work
-        work, created = Work.objects.update_or_create(category=self.anime_category,
-                                                      anidb_aid=anidb_aid,
-                                                      defaults=anime)
+        try:
+            work, created = Work.objects.update_or_create(category=self.anime_category,
+                                                          anidb_aid=anidb_aid,
+                                                          defaults=anime)
+        except MultipleObjectsReturned:
+            return None
 
         # Add new creators
         for nc in creators:

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -258,7 +258,8 @@ class AniDB:
         :param reload_lang_cache: forcefully reload the ExtLanguage cache,
             if it has changed since the instantiation of the AniDB client (default: false).
         :type reload_lang_cache: boolean
-        :return: the Work object related to the AniDB ID passed in parameter.
+        :return: the Work object related to the AniDB ID passed in parameter,
+            None if two or more Work objects match the AniDB ID provided.
         :rtype: a `mangaki.models.Work` object.
         """
 


### PR DESCRIPTION
Adresses an issue in the admin panel when two or more Works have the same AniDB identifiant and a `MultipleObjectsReturned` exception happens when refreshing the Work from AniDB.

Now, instead of having an error, no modifications are made and the user is alerted of that conflict !

*Also adds tests for refreshing data from AniDB from the admin panel*