### PR TITLE
Reduce the amount of queries in AniDB's API wrapper

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -245,7 +245,7 @@ class WorkAdmin(admin.ModelAdmin):
                 tags.update(added_tags)
                 tags.update(updated_tags)
 
-                anime.update_tags(tags)
+                client.update_tags(anime, tags)
 
             self.message_user(request, "Modifications sur les tags faites")
             return None

--- a/mangaki/mangaki/management/commands/anidb.py
+++ b/mangaki/mangaki/management/commands/anidb.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
                 tags.update(added_tags)
                 tags.update(updated_tags)
                 tags.update(kept_tags)
-                anime.update_tags(tags)
+                client.update_tags(anime, tags)
 
             staff_map = dict(Role.objects.filter(slug__in=['author', 'director', 'composer']).values_list('slug', 'pk'))
 

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -165,7 +165,7 @@ class Work(models.Model):
         return reverse('work-detail', args=[self.category.slug, str(self.id)])
 
     def retrieve_tags(self, anidb):
-        anidb_tags = anidb.handle_tags(anidb_aid=self.anidb_aid)
+        anidb_tags = anidb.get_tags(anidb_aid=self.anidb_aid)
 
         tag_work_list = TaggedWork.objects.filter(work=self).all()
         values = tag_work_list.values_list('tag__title', 'tag__anidb_tag_id', 'weight')

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -24,7 +24,6 @@ class AniDBTest(TestCase):
         self.anidb = AniDB('test_client', 1)
         self.no_anidb = AniDB()
         self.search_fixture = self.read_fixture('search_sangatsu_no_lion.xml')
-        self.anime_fixture = self.read_fixture('anidb/sangatsu_no_lion.xml')
 
     def test_to_python_datetime(self):
         self.assertEqual(to_python_datetime('2017-12-25'), datetime(2017, 12, 25, 0, 0))
@@ -49,6 +48,28 @@ class AniDBTest(TestCase):
         results = self.anidb.search(q=anime_query)
         self.assertEqual(len(results), 2)
         self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_anidb_get_methods(self):
+        responses.add(
+            responses.GET,
+            AniDB.BASE_URL,
+            body=self.read_fixture('anidb/sangatsu_no_lion.xml'),
+            status=200,
+            content_type='application/xml'
+        )
+
+        titles, main_title = self.anidb.get_titles(anidb_aid=11606)
+        creators, studio = self.anidb.get_creators(anidb_aid=11606)
+        tags = self.anidb.get_tags(anidb_aid=11606)
+        related_animes = self.anidb.get_related_animes(anidb_aid=11606)
+
+        self.assertEqual(len(titles), 9)
+        self.assertEqual(main_title, 'Sangatsu no Lion')
+        self.assertEqual(len(creators), 4)
+        self.assertEqual(studio.title, 'Shaft')
+        self.assertEqual(len(tags), 30)
+        self.assertEqual(len(related_animes), 2)
 
     @responses.activate
     def test_anidb_get_animes(self):

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -338,13 +338,16 @@ class AniDB:
             artist = Artist.objects.filter(Q(name=nc["name"]) | Q(anidb_creator_id=nc["anidb_creator_id"])).first()
 
             if not artist: # This artist does not yet exist
-                artist, a_created = Artist.objects.get_or_create(name=nc["name"], anidb_creator_id=nc["anidb_creator_id"])
+                artist = Artist(name=nc["name"], anidb_creator_id=nc["anidb_creator_id"])
             else: # This artist exists : prevent duplicates by updating with the AniDB id
                 artist.name = nc["name"]
                 artist.anidb_creator_id = nc["anidb_creator_id"]
-                artist.save()
+            artist.save()
 
-            Staff.objects.update_or_create(work=work, role_id=nc["role_id"], artist=artist)
+            staff = Staff.objects.filter(work=work, role_id=nc["role_id"], artist=artist).first()
+            if not staff: # This staff does not yet exist so we create it
+                staff = Staff(work=work, role_id=nc["role_id"], artist=artist)
+                staff.save()
 
         tags = self.handle_tags(tags_soup=all_tags)
         work.update_tags(tags)

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -266,6 +266,62 @@ class AniDB:
 
         return tags
 
+    def update_tags(self,
+                    work: Work,
+                    anidb_tags: Dict[str, Dict[str, Any]]):
+        tag_work_list = TaggedWork.objects.filter(work=work).all()
+        values = tag_work_list.values_list('tag__title', 'tag__anidb_tag_id', 'weight')
+        current_tags = {
+            value[0]: {
+                "weight": value[2],
+                "anidb_tag_id": value[1]
+            } for value in values
+        }
+
+        deleted_tags_keys = current_tags.keys() - anidb_tags.keys()
+
+        added_tags_keys = anidb_tags.keys() - current_tags.keys()
+        added_tags = {key: anidb_tags[key] for key in added_tags_keys}
+
+        tags_id = [added_tags[title]["anidb_tag_id"] for title in added_tags]
+        existing_tags = Tag.objects.filter(anidb_tag_id__in=tags_id).all()
+        existing_tags_id = existing_tags.values_list('anidb_tag_id', flat=True)
+
+        remaining_tags_keys = list(set(current_tags.keys()).intersection(anidb_tags.keys()))
+        updated_tags = {key: anidb_tags[key] for key in remaining_tags_keys if current_tags[key] != anidb_tags[key]}
+
+        # New tags have to be added to the database (if they aren't already present)
+        tags_weight = {}
+        tags_to_add = []
+        tags_list = []
+        for title, tag_infos in added_tags.items():
+            anidb_tag_id = tag_infos["anidb_tag_id"]
+            tags_weight[anidb_tag_id] = tag_infos["weight"]
+            if anidb_tag_id not in existing_tags_id:
+                tag = Tag(title=title, anidb_tag_id=anidb_tag_id)
+                tags_to_add.append(tag)
+            else:
+                tag = existing_tags.filter(anidb_tag_id=anidb_tag_id).first()
+            tags_list.append(tag)
+        Tag.objects.bulk_create(tags_to_add)
+
+        # Assign tags to the work via TaggedWork
+        tagged_works_to_add = []
+        for tag in tags_list:
+            tag_weight = tags_weight[tag.anidb_tag_id]
+            tagged_work = TaggedWork(tag=tag, work=work, weight=tag_weight)
+            tagged_works_to_add.append(tagged_work)
+        TaggedWork.objects.bulk_create(tagged_works_to_add)
+
+        # Update the weight of tags that already exist (only if the weight changed)
+        for title, tag_infos in updated_tags.items():
+            tagged_work = work.taggedwork_set.get(tag__title=title)
+            tagged_work.weight = tag_infos["weight"]
+            tagged_work.save()
+
+        # Finally, remove a tag from a work if it no longer exists on AniDB's side
+        TaggedWork.objects.filter(work=work, tag__title__in=deleted_tags_keys).delete()
+
     def get_related_animes(self, anidb_aid=None, related_animes_soup=None):
         if anidb_aid is not None:
             anime = self.get_xml(anidb_aid)
@@ -387,7 +443,7 @@ class AniDB:
 
         # Add tags for this work to the database
         tags = self.handle_tags(tags_soup=all_tags)
-        work.update_tags(tags)
+        self.update_tags(work, tags)
 
         # Check for NSFW based on tags if this work is new
         if created and work.is_nsfw_based_on_tags(tags):

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -160,6 +160,29 @@ class AniDB:
 
         return soup.anime
 
+    def get_titles(self, anidb_aid=None, titles_soup=None):
+        if anidb_aid is not None:
+            anime = self.get_xml(anidb_aid)
+            titles_soup = anime.titles
+
+        main_title = None
+        titles = []
+        for title_node in titles_soup.find_all('title'):
+            title = str(title_node.string).strip()
+            lang = title_node.get('xml:lang')
+            title_type = title_node.get('type')
+
+            titles.append({
+                'title': title,
+                'lang': lang,
+                'type': title_type
+            })
+
+            if title_type == 'main':
+                main_title = title
+
+        return titles, main_title
+
     def get_creators(self, anidb_aid=None, creators_soup=None):
         if anidb_aid is not None:
             anime = self.get_xml(anidb_aid)
@@ -307,21 +330,7 @@ class AniDB:
         all_related_animes = anime.relatedanime
 
         # Handling of titles
-        main_title = None
-        titles = []
-        for title_node in all_titles.find_all('title'):
-            title = str(title_node.string).strip()
-            lang = title_node.get('xml:lang')
-            title_type = title_node.get('type')
-
-            titles.append({
-                'title': title,
-                'lang': lang,
-                'type': title_type
-            })
-
-            if title_type == 'main':
-                main_title = title
+        titles, main_title = self.get_titles(titles_soup=all_titles)
 
         # Handling of staff and studio
         creators, studio = self.get_creators(creators_soup=all_creators)

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -248,7 +248,7 @@ class AniDB:
 
         Staff.objects.bulk_create(staffs_to_add)
 
-    def handle_tags(self, anidb_aid=None, tags_soup=None):
+    def get_tags(self, anidb_aid=None, tags_soup=None):
         if anidb_aid is not None:
             anime = self.get_xml(anidb_aid)
             tags_soup = anime.tags
@@ -442,7 +442,7 @@ class AniDB:
         self._build_staff(work, creators)
 
         # Add tags for this work to the database
-        tags = self.handle_tags(tags_soup=all_tags)
+        tags = self.get_tags(tags_soup=all_tags)
         self.update_tags(work, tags)
 
         # Check for NSFW based on tags if this work is new

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -110,7 +110,6 @@ class AniDB:
 
     def get_xml(self, anidb_aid: int):
         """Return the XML file for an anime from AniDB given its AniDB ID"""
-        anidb_aid = int(anidb_aid)
 
         r = self._request("anime", {'aid': anidb_aid})
         soup = BeautifulSoup(r.text.encode('utf-8'), 'xml')


### PR DESCRIPTION
In this PR, the goal is to improve the AniDB API wrapper :
- Move the `update_tags` method from `models.py` to `utils/anidb.py` (makes more sense)
- Create some methods to improve readability of the `get_or_update_work` method
- Reduce the amount of queries overall : improve the way staff is added to the database
- Clean the code for the wrapper slightly