### PR TITLE
Find neighbors of a poster

### DIFF
--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -1,0 +1,113 @@
+from collections import Counter
+import json
+import time
+import os
+import argparse
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from mangaki.models import Work
+
+import numpy as np
+import pandas as pd
+from scipy.spatial.distance import pdist, squareform
+from PIL import Image, ImageFont, ImageDraw
+
+
+def create_collage(width, height, listofimages):
+    cols = len(listofimages)
+    collage = Image.new('RGBA', (width*len(listofimages), height))
+    draw = ImageDraw.Draw(collage)
+    names = [os.path.relpath(os.path.splitext(path)[0], 'posters') for path in listofimages]
+
+    ims = []
+    for p in listofimages:
+        im = Image.open(p)
+        im.thumbnail((width, height))
+        ims.append(im)
+
+    x = 0
+    for col in range(cols):
+        if col == 1:
+            x += 5
+
+        pos_x = int(x+(width-ims[col].width)/2)
+        pos_y = height-ims[col].height
+        collage.paste(ims[col], (pos_x, pos_y))
+
+        text_w, text_h = draw.textsize(names[col])
+        text_x = int(pos_x + (ims[col].width-text_w)/2)
+        text_y = height-25
+
+        draw.text((text_x-1, text_y-1), names[col], fill=(255,255,255))
+        draw.text((text_x+1, text_y-1), names[col], fill=(255,255,255))
+        draw.text((text_x-1, text_y+1), names[col], fill=(255,255,255))
+        draw.text((text_x+1, text_y+1), names[col], fill=(255,255,255))
+        draw.text((text_x, text_y), names[col], (0,0,0))
+
+        x += width
+
+    draw.line((width,0,width,height), fill=(0,0,0), width=5)
+
+    if not os.path.exists('collages'):
+        os.makedirs('collages')
+    collage.save('collages/collage_{}.png'.format(names[0]))
+
+NUMBER_CLOSESTS = 7
+CATEGORY_WEIGHTS = {'character': 1, 'rating': 1, 'general': 1, 'copyright': 1}
+SAVE_FILE = 'posters_neighborships.pkl'
+
+class Command(BaseCommand):
+    help = 'Find closest neighbors to a poster for a work'
+
+    def add_arguments(self, parser):
+        parser.add_argument('poster', nargs='+', type=int)
+
+    def handle(self, *args, **options):
+        ids_wanted = options['poster']
+        posters_wanted = ['{}.jpg'.format(id_wanted) for id_wanted in ids_wanted]
+
+        # Try to retrieve already saved neighborship information
+        if os.path.isfile(SAVE_FILE):
+            neighborship = pd.read_pickle(SAVE_FILE)
+            self.stdout.write('Loaded neighborship data from pickle\n')
+        else:
+            # Open the JSON i2v file
+            with open(os.path.join(settings.DATA_DIR, 'mangaki_i2v.json'), encoding='utf-8') as f_i2v:
+                i2v = json.load(f_i2v)
+
+            # Let's make a {poster: tags} dict to simplify things up
+            processed_data = {}
+            for poster in i2v:
+                tags_dict = {}
+                for category, tags in i2v[poster].items():
+                    for tag, weight in tags:
+                        tags_dict[tag] = weight * CATEGORY_WEIGHTS[category]
+                processed_data[poster] = tags_dict
+
+            # Calculate euclidean distances poster to poster
+            self.stdout.write('Calculating matrix of euclidean distances ...')
+            start_time = time.time()
+            df = pd.DataFrame(processed_data).fillna(0).transpose()
+            q = squareform(pdist(df, 'euclidean'))
+            neighborship = pd.DataFrame(q, index=df.index, columns=df.index)
+            self.stdout.write('Compute time : '+str(time.time()-start_time))
+
+            # And finally save those for later
+            # neighborship.to_pickle(SAVE_FILE)
+            self.stdout.write('Saved neighborship data to pickle\n')
+
+        # Make a collage of images for each poster passed as an argument
+        for poster in ids_wanted:
+            curr_poster_filename = '{}.jpg'.format(poster)
+
+            try:
+                closests = neighborship[curr_poster_filename].sort_values('index').axes[0].tolist()[:NUMBER_CLOSESTS+1]
+                names = [os.path.splitext(filename)[0] for filename in closests[1:]]
+                listofimages = ['posters/'+name for name in closests]
+
+                self.stdout.write('Closest to {} : {}'.format(poster, ', '.join(names)))
+                # create_collage(90, 150, listofimages)
+            except:
+                self.stdout.write('Could not find {} ...'.format(poster))
+                continue

--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -4,11 +4,9 @@ import os
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
-from mangaki.models import Work
 
 import numpy as np
 import pandas as pd
-from scipy.spatial.distance import pdist, squareform
 from sklearn.metrics.pairwise import euclidean_distances
 from PIL import Image, ImageFont, ImageDraw
 
@@ -75,7 +73,7 @@ class Command(BaseCommand):
         with open(os.path.join(settings.DATA_DIR, 'mangaki_i2v.json'), encoding='utf-8') as f_i2v:
             i2v = json.load(f_i2v)
 
-            # Let's make a {poster_id: tags} dict to simplify things up
+            # Let's make a {poster_id: tags} dict
             for poster in i2v:
                 tags_dict = {}
                 poster_id = int(os.path.splitext(poster)[0])
@@ -93,12 +91,9 @@ class Command(BaseCommand):
             return
 
         # Calculate euclidean distances from the wanted poster to all other posters
-        # self.stdout.write('Calculating matrix of euclidean distances ...')
-        # start_time = time.time()
         distances = euclidean_distances(df.loc[id_wanted].values.reshape(1, -1), df)
         neighborship = pd.DataFrame(distances, index=[id_wanted], columns=df.index)
         distances = None
-        # self.stdout.write(self.style.SUCCESS('Compute time : '+str(time.time()-start_time)))
 
         # Display ID of neighbors for a poster and make a collage if flag passed as argument
         if id_wanted in neighborship:

--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -1,7 +1,6 @@
 import json
 import time
 import os
-import gc
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -14,90 +13,101 @@ from sklearn.metrics.pairwise import euclidean_distances
 from PIL import Image, ImageFont, ImageDraw
 
 
-# def create_collage(width, height, listofimages):
-#     cols = len(listofimages)
-#     collage = Image.new('RGBA', (width*len(listofimages), height))
-#     draw = ImageDraw.Draw(collage)
-#     names = [os.path.relpath(os.path.splitext(path)[0], 'posters') for path in listofimages]
-#
-#     ims = []
-#     for p in listofimages:
-#         im = Image.open(p)
-#         im.thumbnail((width, height))
-#         ims.append(im)
-#
-#     x = 0
-#     for col in range(cols):
-#         if col == 1:
-#             x += 5
-#
-#         pos_x = int(x+(width-ims[col].width)/2)
-#         pos_y = height-ims[col].height
-#         collage.paste(ims[col], (pos_x, pos_y))
-#
-#         text_w, text_h = draw.textsize(names[col])
-#         text_x = int(pos_x + (ims[col].width-text_w)/2)
-#         text_y = height-25
-#
-#         draw.text((text_x-1, text_y-1), names[col], fill=(255,255,255))
-#         draw.text((text_x+1, text_y-1), names[col], fill=(255,255,255))
-#         draw.text((text_x-1, text_y+1), names[col], fill=(255,255,255))
-#         draw.text((text_x+1, text_y+1), names[col], fill=(255,255,255))
-#         draw.text((text_x, text_y), names[col], (0,0,0))
-#
-#         x += width
-#
-#     draw.line((width,0,width,height), fill=(0,0,0), width=5)
-#
-#     if not os.path.exists('collages'):
-#         os.makedirs('collages')
-#     collage.save('collages/collage_{}.png'.format(names[0]))
-
 NUMBER_CLOSESTS = 5
 CATEGORY_WEIGHTS = {'character': 1, 'rating': 1, 'general': 1, 'copyright': 1}
 
+def create_collage(width, height, poster_ids):
+    cols = len(poster_ids)
+    collage = Image.new('RGB', (width*cols, height))
+    draw = ImageDraw.Draw(collage)
+    filenames = [os.path.join(settings.STATIC_ROOT, 'img/posters/{}.jpg'.format(pid)) for pid in poster_ids]
+
+    ims = []
+    for poster in filenames:
+        im = Image.open(poster)
+        im.thumbnail((width, height))
+        ims.append(im)
+
+    x = 0
+    for col in range(cols):
+        if col == 1:
+            x += 5
+
+        pos_x = int(x+(width-ims[col].width)/2)
+        pos_y = height-ims[col].height
+        collage.paste(ims[col], (pos_x, pos_y))
+
+        text_w, text_h = draw.textsize(str(poster_ids[col]))
+        text_x = int(pos_x + (ims[col].width-text_w)/2)
+        text_y = height-25
+
+        draw.text((text_x-1, text_y-1), str(poster_ids[col]), fill=(255,255,255))
+        draw.text((text_x+1, text_y-1), str(poster_ids[col]), fill=(255,255,255))
+        draw.text((text_x-1, text_y+1), str(poster_ids[col]), fill=(255,255,255))
+        draw.text((text_x+1, text_y+1), str(poster_ids[col]), fill=(255,255,255))
+        draw.text((text_x, text_y), str(poster_ids[col]), (0,0,0))
+
+        x += width
+
+    draw.line((width,0,width,height), fill=(0,0,0), width=5)
+
+    collages_path = os.path.join(settings.STATIC_ROOT, 'img/posters_collages')
+    if not os.path.exists(collages_path):
+        os.makedirs(collages_path)
+    collage.save(os.path.join(settings.STATIC_ROOT, 'img/posters_collages/collage_{}.jpg'.format(poster_ids[0])))
+
+
 class Command(BaseCommand):
-    help = 'Find closest neighbors to a poster for a work'
+    help = "Find closest posters neighbors to a work's poster"
 
     def add_arguments(self, parser):
         parser.add_argument('poster_id', nargs=1, type=int)
+        parser.add_argument('--collage', dest='collage', action='store_true')
 
     def handle(self, *args, **options):
         id_wanted = options['poster_id'][0]
         poster_wanted = '{}.jpg'.format(id_wanted)
 
+        processed_data = {}
+        df = None
+
         # Open the JSON i2v file
         with open(os.path.join(settings.DATA_DIR, 'mangaki_i2v.json'), encoding='utf-8') as f_i2v:
             i2v = json.load(f_i2v)
 
-        # Let's make a {poster_id: tags} dict to simplify things up
-        processed_data = {}
-        for poster in i2v:
-            tags_dict = {}
-            poster_id = int(os.path.splitext(poster)[0])
-            for category, tags in i2v[poster].items():
-                for tag, weight in tags:
-                    tags_dict[tag] = weight * CATEGORY_WEIGHTS[category]
-            processed_data[poster_id] = tags_dict
+            # Let's make a {poster_id: tags} dict to simplify things up
+            for poster in i2v:
+                tags_dict = {}
+                poster_id = int(os.path.splitext(poster)[0])
+                for category, tags in i2v[poster].items():
+                    for tag, weight in tags:
+                        tags_dict[tag] = weight * CATEGORY_WEIGHTS[category]
+                processed_data[poster_id] = tags_dict
 
-        if not id_wanted in processed_data:
+            df = pd.DataFrame(processed_data).fillna(0).transpose()
+            i2v = None
+            processed_data = None
+
+        if not id_wanted in df.index:
             self.stdout.write('Could not find {} ...'.format(id_wanted))
             return
 
         # Calculate euclidean distances from the wanted poster to all other posters
         # self.stdout.write('Calculating matrix of euclidean distances ...')
-        start_time = time.time()
-        df = pd.DataFrame(processed_data).fillna(0).transpose()
+        # start_time = time.time()
         distances = euclidean_distances(df.loc[id_wanted].values.reshape(1, -1), df)
         neighborship = pd.DataFrame(distances, index=[id_wanted], columns=df.index)
+        distances = None
         # self.stdout.write(self.style.SUCCESS('Compute time : '+str(time.time()-start_time)))
 
-        # Make a collage of images for each poster passed as an argument
+        # Display ID of neighbors for a poster and make a collage if flag passed as argument
         if id_wanted in neighborship:
             closests = neighborship.loc[id_wanted].sort_values('index').axes[0].tolist()[1:NUMBER_CLOSESTS+1]
             self.stdout.write(', '.join(list(map(str, closests))))
 
-            # listofimages = ['posters/'+str(name)+'.jpg' for name in closests]
-            # create_collage(90, 150, listofimages)
+            if options['collage']:
+                id_list = [id_wanted]
+                id_list.extend(closests)
+                create_collage(90, 150, id_list)
         else:
             self.stdout.write('Could not find {} ...'.format(id_wanted))

--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -61,11 +61,11 @@ class Command(BaseCommand):
     help = 'Find closest neighbors to a poster for a work'
 
     def add_arguments(self, parser):
-        parser.add_argument('poster', nargs='+', type=int)
+        parser.add_argument('poster_id', nargs=1, type=int)
 
     def handle(self, *args, **options):
-        ids_wanted = options['poster']
-        posters_wanted = ['{}.jpg'.format(id_wanted) for id_wanted in ids_wanted]
+        id_wanted = options['poster_id'][0]
+        poster_wanted = '{}.jpg'.format(id_wanted)
 
         # Try to retrieve already saved neighborship information
         if os.path.isfile(SAVE_FILE):
@@ -99,15 +99,12 @@ class Command(BaseCommand):
             # self.stdout.write('Saved neighborship data to pickle\n')
 
         # Make a collage of images for each poster passed as an argument
-        for poster_id in ids_wanted:
-            curr_poster_filename = '{}.jpg'.format(poster_id)
 
-            try:
-                closests = neighborship[poster_id].sort_values('index').axes[0].tolist()[1:NUMBER_CLOSESTS+1]
-                self.stdout.write('Closest to {} : {}'.format(poster_id, ', '.join(list(map(str, closests)))))
+        if id_wanted in neighborship:
+            closests = neighborship[id_wanted].sort_values('index').axes[0].tolist()[1:NUMBER_CLOSESTS+1]
+            self.stdout.write('Closest to {} : {}'.format(id_wanted, ', '.join(list(map(str, closests)))))
 
-                # listofimages = ['posters/'+str(name)+'.jpg' for name in closests]
-                # create_collage(90, 150, listofimages)
-            except:
-                self.stdout.write('Could not find {} ...'.format(poster_id))
-                continue
+            # listofimages = ['posters/'+str(name)+'.jpg' for name in closests]
+            # create_collage(90, 150, listofimages)
+        else:
+            self.stdout.write('Could not find {} ...'.format(id_wanted))

--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -14,46 +14,46 @@ from scipy.spatial.distance import pdist, squareform
 from PIL import Image, ImageFont, ImageDraw
 
 
-def create_collage(width, height, listofimages):
-    cols = len(listofimages)
-    collage = Image.new('RGBA', (width*len(listofimages), height))
-    draw = ImageDraw.Draw(collage)
-    names = [os.path.relpath(os.path.splitext(path)[0], 'posters') for path in listofimages]
+# def create_collage(width, height, listofimages):
+#     cols = len(listofimages)
+#     collage = Image.new('RGBA', (width*len(listofimages), height))
+#     draw = ImageDraw.Draw(collage)
+#     names = [os.path.relpath(os.path.splitext(path)[0], 'posters') for path in listofimages]
+#
+#     ims = []
+#     for p in listofimages:
+#         im = Image.open(p)
+#         im.thumbnail((width, height))
+#         ims.append(im)
+#
+#     x = 0
+#     for col in range(cols):
+#         if col == 1:
+#             x += 5
+#
+#         pos_x = int(x+(width-ims[col].width)/2)
+#         pos_y = height-ims[col].height
+#         collage.paste(ims[col], (pos_x, pos_y))
+#
+#         text_w, text_h = draw.textsize(names[col])
+#         text_x = int(pos_x + (ims[col].width-text_w)/2)
+#         text_y = height-25
+#
+#         draw.text((text_x-1, text_y-1), names[col], fill=(255,255,255))
+#         draw.text((text_x+1, text_y-1), names[col], fill=(255,255,255))
+#         draw.text((text_x-1, text_y+1), names[col], fill=(255,255,255))
+#         draw.text((text_x+1, text_y+1), names[col], fill=(255,255,255))
+#         draw.text((text_x, text_y), names[col], (0,0,0))
+#
+#         x += width
+#
+#     draw.line((width,0,width,height), fill=(0,0,0), width=5)
+#
+#     if not os.path.exists('collages'):
+#         os.makedirs('collages')
+#     collage.save('collages/collage_{}.png'.format(names[0]))
 
-    ims = []
-    for p in listofimages:
-        im = Image.open(p)
-        im.thumbnail((width, height))
-        ims.append(im)
-
-    x = 0
-    for col in range(cols):
-        if col == 1:
-            x += 5
-
-        pos_x = int(x+(width-ims[col].width)/2)
-        pos_y = height-ims[col].height
-        collage.paste(ims[col], (pos_x, pos_y))
-
-        text_w, text_h = draw.textsize(names[col])
-        text_x = int(pos_x + (ims[col].width-text_w)/2)
-        text_y = height-25
-
-        draw.text((text_x-1, text_y-1), names[col], fill=(255,255,255))
-        draw.text((text_x+1, text_y-1), names[col], fill=(255,255,255))
-        draw.text((text_x-1, text_y+1), names[col], fill=(255,255,255))
-        draw.text((text_x+1, text_y+1), names[col], fill=(255,255,255))
-        draw.text((text_x, text_y), names[col], (0,0,0))
-
-        x += width
-
-    draw.line((width,0,width,height), fill=(0,0,0), width=5)
-
-    if not os.path.exists('collages'):
-        os.makedirs('collages')
-    collage.save('collages/collage_{}.png'.format(names[0]))
-
-NUMBER_CLOSESTS = 7
+NUMBER_CLOSESTS = 5
 CATEGORY_WEIGHTS = {'character': 1, 'rating': 1, 'general': 1, 'copyright': 1}
 SAVE_FILE = 'posters_neighborships.pkl'
 
@@ -76,14 +76,15 @@ class Command(BaseCommand):
             with open(os.path.join(settings.DATA_DIR, 'mangaki_i2v.json'), encoding='utf-8') as f_i2v:
                 i2v = json.load(f_i2v)
 
-            # Let's make a {poster: tags} dict to simplify things up
+            # Let's make a {poster_id: tags} dict to simplify things up
             processed_data = {}
             for poster in i2v:
                 tags_dict = {}
+                poster_id = int(os.path.splitext(poster)[0])
                 for category, tags in i2v[poster].items():
                     for tag, weight in tags:
                         tags_dict[tag] = weight * CATEGORY_WEIGHTS[category]
-                processed_data[poster] = tags_dict
+                processed_data[poster_id] = tags_dict
 
             # Calculate euclidean distances poster to poster
             self.stdout.write('Calculating matrix of euclidean distances ...')
@@ -95,19 +96,18 @@ class Command(BaseCommand):
 
             # And finally save those for later
             # neighborship.to_pickle(SAVE_FILE)
-            self.stdout.write('Saved neighborship data to pickle\n')
+            # self.stdout.write('Saved neighborship data to pickle\n')
 
         # Make a collage of images for each poster passed as an argument
-        for poster in ids_wanted:
-            curr_poster_filename = '{}.jpg'.format(poster)
+        for poster_id in ids_wanted:
+            curr_poster_filename = '{}.jpg'.format(poster_id)
 
             try:
-                closests = neighborship[curr_poster_filename].sort_values('index').axes[0].tolist()[:NUMBER_CLOSESTS+1]
-                names = [os.path.splitext(filename)[0] for filename in closests[1:]]
-                listofimages = ['posters/'+name for name in closests]
+                closests = neighborship[poster_id].sort_values('index').axes[0].tolist()[1:NUMBER_CLOSESTS+1]
+                self.stdout.write('Closest to {} : {}'.format(poster_id, ', '.join(list(map(str, closests)))))
 
-                self.stdout.write('Closest to {} : {}'.format(poster, ', '.join(names)))
+                # listofimages = ['posters/'+str(name)+'.jpg' for name in closests]
                 # create_collage(90, 150, listofimages)
             except:
-                self.stdout.write('Could not find {} ...'.format(poster))
+                self.stdout.write('Could not find {} ...'.format(poster_id))
                 continue

--- a/mangaki/mangaki/management/commands/poster_neighbors.py
+++ b/mangaki/mangaki/management/commands/poster_neighbors.py
@@ -61,10 +61,13 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('poster_id', nargs=1, type=int)
         parser.add_argument('--collage', dest='collage', action='store_true')
+        parser.add_argument('--limit', dest='limit', type=int)
 
     def handle(self, *args, **options):
         id_wanted = options['poster_id'][0]
         poster_wanted = '{}.jpg'.format(id_wanted)
+
+        number_neighbors = options['limit'] if options['limit'] else NUMBER_CLOSESTS
 
         processed_data = {}
         df = None
@@ -97,7 +100,7 @@ class Command(BaseCommand):
 
         # Display ID of neighbors for a poster and make a collage if flag passed as argument
         if id_wanted in neighborship:
-            closests = neighborship.loc[id_wanted].sort_values('index').axes[0].tolist()[1:NUMBER_CLOSESTS+1]
+            closests = neighborship.loc[id_wanted].sort_values('index').axes[0].tolist()[1:number_neighbors+1]
             self.stdout.write(', '.join(list(map(str, closests))))
 
             if options['collage']:

--- a/mangaki/setup.py
+++ b/mangaki/setup.py
@@ -30,7 +30,7 @@ setup(
         'coreapi>=2.3<2.4',
         'celery>=4.0<4.1',
         'redis>=2.10<2.11',
-        'PIL'
+        'Pillow'
     ],
     packages=find_packages(),
     include_package_data=True,

--- a/mangaki/setup.py
+++ b/mangaki/setup.py
@@ -30,7 +30,7 @@ setup(
         'coreapi>=2.3<2.4',
         'celery>=4.0<4.1',
         'redis>=2.10<2.11',
-        'Pillow'
+        'Pillow>=4.1'
     ],
     packages=find_packages(),
     include_package_data=True,

--- a/mangaki/setup.py
+++ b/mangaki/setup.py
@@ -30,6 +30,7 @@ setup(
         'coreapi>=2.3<2.4',
         'celery>=4.0<4.1',
         'redis>=2.10<2.11',
+        'PIL'
     ],
     packages=find_packages(),
     include_package_data=True,

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,4 +20,4 @@ djangorestframework==3.6.*
 coreapi==2.3.*
 celery==4.0.*
 redis==2.10.*
-PIL
+Pillow

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,3 +20,4 @@ djangorestframework==3.6.*
 coreapi==2.3.*
 celery==4.0.*
 redis==2.10.*
+PIL


### PR DESCRIPTION
Adds a `poster_neighbors` command which takes a Work ID as an argument (and an optional `--collage` argument) and prints the IDs of Works which posters are (supposedly) close to the one passed as an argument.
Example : `./manage.py poster_neighbors 1 --collage`
The optional `--collage` argument will create a collage of those posters in `static/image/posters_collages`.

This command actually takes up to 400MB of RAM on a single run, so another method to find neighbors for a poster might be better !

*Computing neighbors for a poster uses a `mangaki_i2v.json` JSON file in which tags for posters are stored, previously computed via [illustration2vec](http://illustration2vec.net/).*
