### PR TITLE
Improved administration page for refreshing AniDB tags

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -303,19 +303,19 @@ class WorkAdmin(admin.ModelAdmin):
 
                 anidb_tags = client.get_tags(anidb_aid=work.anidb_aid)
                 tags_diff = diff_between_anidb_and_local_tags(work, anidb_tags)
+                tags_count = 0
 
-                deleted_tags = tags_diff["deleted_tags"]
-                added_tags = tags_diff["added_tags"]
-                updated_tags = tags_diff["updated_tags"]
-                kept_tags = tags_diff["kept_tags"]
+                for tags_info in tags_diff.values():
+                    tags_count += len(tags_info)
 
-                all_information[work.id] = {
-                    'title': work.title,
-                    'deleted_tags': deleted_tags.items(),
-                    'added_tags': added_tags.items(),
-                    'updated_tags': updated_tags.items(),
-                    'kept_tags': kept_tags.items()
-                }
+                if tags_count > 0:
+                    all_information[work.id] = {
+                        'title': work.title,
+                        'deleted_tags': tags_diff["deleted_tags"].items(),
+                        'added_tags': tags_diff["added_tags"].items(),
+                        'updated_tags': tags_diff["updated_tags"].items(),
+                        'kept_tags': tags_diff["kept_tags"].items()
+                    }
 
         if all_information:
             context = {
@@ -326,7 +326,11 @@ class WorkAdmin(admin.ModelAdmin):
                 'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME
             }
             return TemplateResponse(request, "admin/update_tags_via_anidb.html", context)
-        return None
+        else:
+            self.message_user(request,
+                              "Aucune des œuvres sélectionnées n'a subit de mise à jour des tags chez AniDB",
+                              level=messages.WARNING)
+            return None
 
     update_tags_via_anidb.short_description = "Mettre à jour les tags des œuvres depuis AniDB"
 

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -277,7 +277,7 @@ class WorkAdmin(admin.ModelAdmin):
                                   level=messages.WARNING)
             elif nb_updates == 1:
                 self.message_user(request,
-                                  "Mise à jour des tags effectuée pour 1 œuvre.")
+                                  "Mise à jour des tags effectuée pour une œuvre.")
             else:
                 self.message_user(request,
                                   "Mise à jour des tags effectuée pour {} œuvres.".format(nb_updates))

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -234,10 +234,10 @@ class WorkAdmin(admin.ModelAdmin):
         works = queryset.all()
 
         if request.POST.get('confirm'): # Updating tags has been confirmed
-            to_update_work_ids = set(list(map(int, request.POST.getlist('to_update_work_ids'))))
+            to_update_work_ids = set(map(int, request.POST.getlist('to_update_work_ids')))
             nb_updates = len(to_update_work_ids)
 
-            work_ids = list(map(int, request.POST.getlist('work_ids')))
+            work_ids = map(int, request.POST.getlist('work_ids'))
             tag_titles = request.POST.getlist('tag_titles')
             tag_weights = list(map(int, request.POST.getlist('weights')))
             tag_anidb_tag_ids = list(map(int, request.POST.getlist('anidb_tag_ids')))
@@ -245,26 +245,24 @@ class WorkAdmin(admin.ModelAdmin):
 
             # These checkboxes make it possible to know which tags should be added, kept, modified or removed
             tag_checkboxes = request.POST.getlist('tag_checkboxes')
-            tags_to_process = [list(map(int, tag_checkbox.split(':'))) for tag_checkbox in tag_checkboxes]
+            tags_to_process = [tuple(map(int, tag_checkbox.split(':'))) for tag_checkbox in tag_checkboxes]
 
             # Build a dict that links a work ID and the dict of tags
             final_tags_with_work_id = {}
             for index, work_id in enumerate(work_ids):
-                process = [work_id, tag_anidb_tag_ids[index]] in tags_to_process
+                process = (work_id, tag_anidb_tag_ids[index]) in tags_to_process
                 to_delete = tag_operations[index] == 'deleted'
-                to_add_or_update_or_keep = tag_operations[index] in ('added', 'modified', 'kept')
+                to_add_or_update_or_keep = not to_delete or tag_operations[index] in ('added', 'modified', 'kept')
 
-                if not final_tags_with_work_id.get(work_id):
+                if work_id not in final_tags_with_work_id:
                     final_tags_with_work_id[work_id] = {}
 
                 # Only add this tag to the list of tags to process if it has been checked
                 if (process and to_add_or_update_or_keep) or (not process and to_delete):
-                    final_tags_with_work_id[work_id].update({
-                        tag_titles[index]: {
-                            'weight': tag_weights[index],
-                            'anidb_tag_id': tag_anidb_tag_ids[index]
-                        }
-                    })
+                    final_tags_with_work_id[work_id][tag_titles[index]] = {
+                        'weight': tag_weights[index],
+                        'anidb_tag_id': tag_anidb_tag_ids[index]
+                    }
 
             # Process selected tags for works that have been selected
             for work in works:

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -19,7 +19,7 @@ from mangaki.models import (
     FAQEntry, ColdStartRating, Trope, Language,
     ExtLanguage, WorkCluster
 )
-from mangaki.utils.anidb import client, diff_between_anidb_and_local_tags
+from mangaki.utils.anidb import AniDBTag, client, diff_between_anidb_and_local_tags
 from mangaki.utils.db import get_potential_posters
 
 from collections import defaultdict
@@ -309,10 +309,10 @@ class WorkAdmin(admin.ModelAdmin):
                 if tags_count > 0:
                     all_information[work.id] = {
                         'title': work.title,
-                        'deleted_tags': tags_diff["deleted_tags"].items(),
-                        'added_tags': tags_diff["added_tags"].items(),
-                        'updated_tags': tags_diff["updated_tags"].items(),
-                        'kept_tags': tags_diff["kept_tags"].items()
+                        'deleted_tags': tags_diff["deleted_tags"],
+                        'added_tags': tags_diff["added_tags"],
+                        'updated_tags': tags_diff["updated_tags"],
+                        'kept_tags': tags_diff["kept_tags"]
                     }
 
         if all_information:

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -308,7 +308,7 @@ class WorkAdmin(admin.ModelAdmin):
             context = {
                 'all_information': all_information.items(),
                 'queryset': queryset,
-                'opts': Tag._meta,
+                'opts': TaggedWork._meta,
                 'action': 'update_tags_via_anidb',
                 'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME
             }

--- a/mangaki/mangaki/management/commands/anidb.py
+++ b/mangaki/mangaki/management/commands/anidb.py
@@ -79,35 +79,35 @@ class Command(BaseCommand):
             print(anime.title+":")
             if deleted_tags:
                 print("\n\tLes tags enlevés sont :")
-                for tag, tag_infos in deleted_tags.items():
-                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag_infos["anidb_tag_id"], tag, tag_infos["weight"]))
+                for tag in deleted_tags:
+                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag.anidb_tag_id, tag.title, tag.weight))
 
             if added_tags:
                 print("\n\tLes tags totalement nouveaux sont :")
-                for tag, tag_infos in added_tags.items():
-                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag_infos["anidb_tag_id"], tag, tag_infos["weight"]))
+                for tag in added_tags:
+                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag.anidb_tag_id, tag.title, tag.weight))
 
             if updated_tags:
                 print("\n\tLes tags modifiés sont :")
-                for tag, tag_infos in updated_tags.items():
-                    print('\t\t[AniDB Tag ID #{} -> #{}] {}: {} -> {}'.format(
-                        tag_infos[0]["anidb_tag_id"], tag_infos[1]["anidb_tag_id"], tag, tag_infos[0]["weight"], tag_infos[1]["weight"]))
-
+                for tag in updated_tags:
+                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag.anidb_tag_id, tag.title, tag.weight))
 
             if kept_tags:
-                print("\n\tLes tags non modifiés/restés identiques sont :")
-                for tag, tag_infos in kept_tags.items():
-                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag_infos["anidb_tag_id"], tag, tag_infos["weight"]))
+                print("\n\tLes tags identiques sont :")
+                for tag in kept_tags:
+                    print('\t\t[AniDB Tag ID #{}] {}: {} '.format(tag.anidb_tag_id, tag.title, tag.weight))
 
             choice = input("Voulez-vous réaliser ces changements [y/n] : ")
             if choice == 'n':
                 print("\nOk, aucun changement ne va être fait")
             elif choice == 'y':
-                tags = deleted_tags
-                tags.update(added_tags)
-                tags.update(updated_tags)
-                tags.update(kept_tags)
-                client.update_tags(anime, tags)
+                all_tags = []
+                all_tags.extend(deleted_tags)
+                all_tags.extend(added_tags)
+                all_tags.extend(updated_tags)
+                all_tags.extend(kept_tags)
+
+                client.update_tags(anime, all_tags)
 
             staff_map = dict(Role.objects.filter(slug__in=['author', 'director', 'composer']).values_list('slug', 'pk'))
 

--- a/mangaki/mangaki/management/commands/anidb.py
+++ b/mangaki/mangaki/management/commands/anidb.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from django.db.models import Count
-from mangaki.utils.anidb import client
+from mangaki.utils.anidb import client, diff_between_anidb_and_local_tags
 from mangaki.models import Artist, Role, Staff, Work, WorkTitle, ArtistSpelling, Language
 from urllib.parse import parse_qs, urlparse
 
@@ -68,11 +68,13 @@ class Command(BaseCommand):
                 language = Language.objects.get(iso639=worktitle[2])
                 WorkTitle.objects.get_or_create(work=anime, title=worktitle[0], language=language, type=worktitle[1])
 
-            retrieved_tags = anime.retrieve_tags(a)
-            deleted_tags = retrieved_tags["deleted_tags"]
-            added_tags = retrieved_tags["added_tags"]
-            updated_tags = retrieved_tags["updated_tags"]
-            kept_tags = retrieved_tags["kept_tags"]
+            anidb_tags = client.get_tags(anidb_aid=anime.anidb_aid)
+            tags_diff = diff_between_anidb_and_local_tags(anime, anidb_tags)
+
+            deleted_tags = tags_diff["deleted_tags"]
+            added_tags = tags_diff["added_tags"]
+            updated_tags = tags_diff["updated_tags"]
+            kept_tags = tags_diff["kept_tags"]
 
             print(anime.title+":")
             if deleted_tags:

--- a/mangaki/mangaki/management/commands/anidb.py
+++ b/mangaki/mangaki/management/commands/anidb.py
@@ -101,12 +101,7 @@ class Command(BaseCommand):
             if choice == 'n':
                 print("\nOk, aucun changement ne va être fait")
             elif choice == 'y':
-                all_tags = []
-                all_tags.extend(deleted_tags)
-                all_tags.extend(added_tags)
-                all_tags.extend(updated_tags)
-                all_tags.extend(kept_tags)
-
+                all_tags = deleted_tags + added_tags + updated_tags + kept_tags
                 client.update_tags(anime, all_tags)
 
             staff_map = dict(Role.objects.filter(slug__in=['author', 'director', 'composer']).values_list('slug', 'pk'))

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -164,32 +164,6 @@ class Work(models.Model):
     def get_absolute_url(self):
         return reverse('work-detail', args=[self.category.slug, str(self.id)])
 
-    def retrieve_tags(self, anidb):
-        anidb_tags = anidb.get_tags(anidb_aid=self.anidb_aid)
-
-        tag_work_list = TaggedWork.objects.filter(work=self).all()
-        values = tag_work_list.values_list('tag__title', 'tag__anidb_tag_id', 'weight')
-        current_tags = {
-            value[0]: {
-                "weight": value[2],
-                "anidb_tag_id": value[1]
-            } for value in values
-        }
-
-        deleted_tags_keys = current_tags.keys() - anidb_tags.keys()
-        deleted_tags = {key: current_tags[key] for key in deleted_tags_keys}
-
-        added_tags_keys = anidb_tags.keys() - current_tags.keys()
-        added_tags = {key: anidb_tags[key] for key in added_tags_keys}
-
-        remaining_tags_keys = list(set(current_tags.keys()).intersection(anidb_tags.keys()))
-        remaining_tags = {key: current_tags[key] for key in remaining_tags_keys}
-
-        updated_tags = {title: (current_tags[title], anidb_tags[title]) for title in remaining_tags if current_tags[title] != anidb_tags[title]}
-        kept_tags = {title: current_tags[title] for title in remaining_tags if current_tags[title] == anidb_tags[title]}
-
-        return {"deleted_tags": deleted_tags, "added_tags": added_tags, "updated_tags": updated_tags, "kept_tags": kept_tags}
-
     def is_nsfw_based_on_tags(self, anidb_tags):
         # FIXME: potentially NSFW tags should be stored somewhere else
         potentially_nsfw_tags = ['nudity', 'ecchi', 'pantsu', 'breasts', 'sex',

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -175,15 +175,13 @@ class Work(models.Model):
         HIGH_NSFW_THRESHOLD = 15
         LOW_NSFW_THRESHOLD = 30
 
-        sum_weight_all_low = sum(infos["weight"] for infos in anidb_tags.values()
-                                 if infos["weight"] <= 400)
-        sum_weight_nsfw_low = sum(infos["weight"] for t, infos in anidb_tags.items()
-                                  if t in potentially_nsfw_tags and infos["weight"] <= 400)
+        sum_weight_all_low = sum(tag.weight for tag in anidb_tags if tag.weight <= 400)
+        sum_weight_nsfw_low = sum(tag.weight for tag in anidb_tags
+                                  if tag.title in potentially_nsfw_tags and tag.weight <= 400)
 
-        sum_weight_all_high = sum(infos["weight"] for infos in anidb_tags.values()
-                                  if infos["weight"] > 400)
-        sum_weight_nsfw_high = sum(infos["weight"] for t, infos in anidb_tags.items()
-                                   if t in potentially_nsfw_tags and infos["weight"] > 400)
+        sum_weight_all_high = sum(tag.weight for tag in anidb_tags if tag.weight > 400)
+        sum_weight_nsfw_high = sum(tag.weight for tag in anidb_tags
+                                   if tag.title in potentially_nsfw_tags and tag.weight > 400)
 
         if sum_weight_all_low > 0 and sum_weight_all_high > 0:
             percent_low_nsfw = (sum_weight_nsfw_low/sum_weight_all_low) * 100

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -164,34 +164,6 @@ class Work(models.Model):
     def get_absolute_url(self):
         return reverse('work-detail', args=[self.category.slug, str(self.id)])
 
-    def is_nsfw_based_on_tags(self, anidb_tags):
-        # FIXME: potentially NSFW tags should be stored somewhere else
-        potentially_nsfw_tags = ['nudity', 'ecchi', 'pantsu', 'breasts', 'sex',
-                                 'large breasts', 'small breasts', 'gigantic breasts',
-                                 'incest', 'pornography', 'shota', 'masturbation',
-                                 'sexual fantasies', 'anal', 'loli']
-
-         # FIXME: these should be configurable constants
-        HIGH_NSFW_THRESHOLD = 15
-        LOW_NSFW_THRESHOLD = 30
-
-        sum_weight_all_low = sum(tag.weight for tag in anidb_tags if tag.weight <= 400)
-        sum_weight_nsfw_low = sum(tag.weight for tag in anidb_tags
-                                  if tag.title in potentially_nsfw_tags and tag.weight <= 400)
-
-        sum_weight_all_high = sum(tag.weight for tag in anidb_tags if tag.weight > 400)
-        sum_weight_nsfw_high = sum(tag.weight for tag in anidb_tags
-                                   if tag.title in potentially_nsfw_tags and tag.weight > 400)
-
-        if sum_weight_all_low > 0 and sum_weight_all_high > 0:
-            percent_low_nsfw = (sum_weight_nsfw_low/sum_weight_all_low) * 100
-            percent_high_nsfw = (sum_weight_nsfw_high/sum_weight_all_high) * 100
-        else:
-            return False
-
-        return (percent_high_nsfw > HIGH_NSFW_THRESHOLD or
-                percent_low_nsfw > LOW_NSFW_THRESHOLD)
-
     def safe_poster(self, user):
         if self.id is None:
             return '{}{}'.format(settings.STATIC_URL, 'img/chiro.gif')

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -29,6 +29,7 @@
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ work_id }}" name="work_ids" />
         </p>
     {% endfor %}
 {% else %}
@@ -45,6 +46,7 @@
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ work_id }}" name="work_ids" />
         </p>
     {% endfor %}
 {% else %}
@@ -61,6 +63,7 @@
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.1.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ work_id }}" name="work_ids" />
         </p>
     {% endfor %}
 {% else %}
@@ -77,6 +80,7 @@
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ work_id }}" name="work_ids" />
         </p>
     {% endfor %}
 {% else %}
@@ -89,7 +93,7 @@
 <p>Quelles sont les œuvres dont vous souhaitez mettre les tags à jour ?</p>
 <div>
     {% for work_id, value in all_information %}
-    <p><label><input type="checkbox" name="checks" value="{{ work_id }}" /> {{ value.title }} </label></p>
+    <p><label><input type="checkbox" name="to_update_work_ids" value="{{ work_id }}" /> {{ value.title }} </label></p>
     {% endfor %}
 
     {% for obj in queryset %}

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -36,14 +36,14 @@
 <div>
 <p style="color: red;"><strong>Tags supprimés&nbsp;:</strong></p>
     <ul>
-    {% for tag_title, tag_infos in value.deleted_tags %}
+    {% for tag in value.deleted_tags %}
         <li>
-            <strong>{{ tag_title }}</strong>, avec un poids de {{ tag_infos.weight }}&nbsp;
-            <input type="hidden" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+            <strong>{{ tag.title }}</strong>, avec un poids de {{ tag.weight }}&nbsp;
+            <input type="hidden" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
 
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
+            <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
             <input type="hidden" value="deleted" name="tag_operations" />
         </li>
@@ -56,14 +56,14 @@
 <div>
 <p style="color: green;"><strong>Tags ajoutés&nbsp;:</strong></p>
     <ul>
-    {% for tag_title, tag_infos in value.added_tags %}
+    {% for tag in value.added_tags %}
         <li>
-            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+            <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
 
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
+            <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
             <input type="hidden" value="added" name="tag_operations" />
         </li>
@@ -76,14 +76,14 @@
 <div>
 <p style="color: orange;"><strong>Tags modifiés&nbsp;:</strong></p>
     <ul>
-    {% for tag_title, tag_infos in value.updated_tags %}
+    {% for tag in value.updated_tags %}
         <li>
-            <strong><label for="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}">{{ tag_title }}</label></strong>, dont le poids passe de {{ tag_infos.0.weight }} à&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />&nbsp;
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.1.anidb_tag_id }}" checked />
+            <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
 
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="hidden" value="{{ tag_infos.1.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
+            <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
             <input type="hidden" value="modified" name="tag_operations" />
         </li>
@@ -96,14 +96,14 @@
 <div>
 <p><strong>Tags conservés&nbsp;:</strong></p>
     <ul>
-    {% for tag_title, tag_infos in value.kept_tags %}
+    {% for tag in value.kept_tags %}
         <li>
-            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />&nbsp;
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+            <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
 
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
+            <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
             <input type="hidden" value="kept" name="tag_operations" />
         </li>

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -1,65 +1,68 @@
 {% extends "admin/base_site.html" %}
-{% load staticfiles %} 
+{% load i18n l10n admin_urls %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; Mettre à jour les tags depuis AniDB
+</div>
+{% endblock %}
 
 {% block content %}
+<form method="post">
+{% csrf_token %}
 
 {% for key, value in all_information %}
 
-{{value.title}}
-    
-    <p>Les tags enlevés sont:</p>
+<strong>{{value.title}}</strong>
+
+<div>
+    <p style="color: red;">Tags supprimés&nbsp;:</p>
     {% for tag, weight in value.deleted_tags %}
-        <p> &nbsp;&nbsp;&nbsp; {{tag}} : {{weight}} </p>
+        <p>{{tag}} : {{weight}} </p>
     {% endfor %}
+</div>
 
-    <p></p>
-    
-    <p>Les tous nouveaux tags sont:</p>
+<div>
+    <p style="color: green;">Tags ajoutés&nbsp;:</p>
     {% for tag, weight in value.added_tags %}
-        <p> &nbsp;&nbsp;&nbsp; {{tag}} :  {{weight}} </p>
+        <p>{{tag}} :  {{weight}} </p>
     {% endfor %}
+</div>
 
-    <p></p>
-    
-    <p>Les tags modifiés sont :</p>
-    {% for tag, weight in value.updated_tags %}            
-        <p> &nbsp;&nbsp;&nbsp; {{tag}} : {{weight.0}} -> {{weight.1}} </p>
+<div>
+    <p style="color: orange;">Tags modifiés&nbsp;:</p>
+    {% for tag, weight in value.updated_tags %}
+        <p>{{tag}} : {{weight.0}} -> {{weight.1}} </p>
     {% endfor %}
+</div>
 
-    <p></p>
-
-    <p>Les tags non modifiés/restés identiques sont:</p>
+<div>
+    <p>Tags conservés&nbsp;:</p>
     {% for tag, weight in value.kept_tags %}
-        <p> &nbsp;&nbsp;&nbsp; {{tag}} : {{weight}} </p>
+        <p>{{tag}} : {{weight}} </p>
+    {% endfor %}
+</div>
+
+{% endfor %}
+
+<p>Quelles sont les œuvres dont vous souhaitez mettre les tags à jour ?</p>
+<div>
+    {% for key, value in all_information %}
+    <p><label><input type="checkbox" name="checks" value="{{ key }}" /> {{ value.title }} </label></p>
     {% endfor %}
 
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-
-{% endfor %}
-
-<form action="" method="post">{% csrf_token %}
-<ul>
-{% for key, value in all_information %}
-<li><label><input type="checkbox" name="checks" value="{{ key }}" /> {{ value.title }} </label></li>
-
-{% endfor %}
-</ul>
-
-{% for key, value in all_information %}
-<input type="hidden" name="{{ action_checkbox_name }}" value="{{ key }}" />
-{% endfor %}
-
-<input type="hidden" name="action" value="update_tags_via_anidb" />
-<input type="hidden" name="post" value="yes" />
-<input type="submit" value="faire les modifications sur les oeuvres sélectionnées" />
+    {% for obj in queryset %}
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
+    {% endfor %}
+    <input type="hidden" name="action" value="{{ action }}" />
+    <input type="hidden" name="confirm" value="yes" />
+    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+    <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
 </div>
 </form>
-
 {% endblock %}

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -16,44 +16,80 @@
 <form method="post">
 {% csrf_token %}
 
-{% for key, value in all_information %}
+{% for work_id, value in all_information %}
 
-<strong>{{value.title}}</strong>
+<h1>(#{{ work_id }}) {{ value.title }}</h1>
 
 <div>
-    <p style="color: red;">Tags supprimés&nbsp;:</p>
-    {% for tag, weight in value.deleted_tags %}
-        <p>{{tag}} : {{weight}} </p>
+<p style="color: red;"><strong>Tags supprimés&nbsp;:</strong></p>
+{% if value.deleted_tags %}
+    {% for tag_title, tag_infos in value.deleted_tags %}
+        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
+            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+        </p>
     {% endfor %}
+{% else %}
+    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été supprimé.</p>
+{% endif %}
 </div>
 
 <div>
-    <p style="color: green;">Tags ajoutés&nbsp;:</p>
-    {% for tag, weight in value.added_tags %}
-        <p>{{tag}} :  {{weight}} </p>
+<p style="color: green;"><strong>Tags ajoutés&nbsp;:</strong></p>
+{% if value.added_tags %}
+    {% for tag_title, tag_infos in value.added_tags %}
+        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
+            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+        </p>
     {% endfor %}
+{% else %}
+    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été ajouté.</p>
+{% endif %}
 </div>
 
 <div>
-    <p style="color: orange;">Tags modifiés&nbsp;:</p>
-    {% for tag, weight in value.updated_tags %}
-        <p>{{tag}} : {{weight.0}} -> {{weight.1}} </p>
+<p style="color: orange;"><strong>Tags modifiés&nbsp;:</strong></p>
+{% if value.updated_tags %}
+    {% for tag_title, tag_infos in value.updated_tags %}
+        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+            <strong><label for="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}">{{ tag_title }}</label></strong>, dont le poids passe de {{ tag_infos.0.weight }} à&nbsp;
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />
+            <input type="hidden" value="{{ tag_infos.1.anidb_tag_id }}" name="anidb_tag_ids" />
+        </p>
     {% endfor %}
+{% else %}
+    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été modifié.</p>
+{% endif %}
 </div>
 
 <div>
-    <p>Tags conservés&nbsp;:</p>
-    {% for tag, weight in value.kept_tags %}
-        <p>{{tag}} : {{weight}} </p>
+<p><strong>Tags conservés&nbsp;:</strong></p>
+{% if value.kept_tags %}
+    {% for tag_title, tag_infos in value.kept_tags %}
+        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
+            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+        </p>
     {% endfor %}
+{% else %}
+    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été conservé.</p>
+{% endif %}
 </div>
 
 {% endfor %}
 
 <p>Quelles sont les œuvres dont vous souhaitez mettre les tags à jour ?</p>
 <div>
-    {% for key, value in all_information %}
-    <p><label><input type="checkbox" name="checks" value="{{ key }}" /> {{ value.title }} </label></p>
+    {% for work_id, value in all_information %}
+    <p><label><input type="checkbox" name="checks" value="{{ work_id }}" /> {{ value.title }} </label></p>
     {% endfor %}
 
     {% for obj in queryset %}

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -38,14 +38,14 @@
     <ul>
     {% for tag in value.deleted_tags %}
         <li>
-            <strong>{{ tag.title }}</strong>, avec un poids de {{ tag.weight }}&nbsp;
+            <strong>{{ tag.title }}</strong>, avec un poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" name="fake_weights" disabled />&nbsp;&nbsp;&nbsp;—
             <input type="hidden" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
+            <strong><label>Conserver ?&nbsp;&nbsp;<input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" /></label></strong>
 
             <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
             <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-            <input type="hidden" value="deleted" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -59,13 +59,12 @@
     {% for tag in value.added_tags %}
         <li>
             <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;&nbsp;&nbsp;—
+            <strong><label>Ajouter ?&nbsp;&nbsp;<input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked /></label></strong>
 
             <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
             <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-            <input type="hidden" value="added" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -78,14 +77,13 @@
     <ul>
     {% for tag in value.updated_tags %}
         <li>
-            <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
+            <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un nouveau poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;&nbsp;&nbsp;—
+            <strong><label>Modifier ?&nbsp;&nbsp;<input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked /></label></strong>
 
             <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
             <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-            <input type="hidden" value="modified" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -99,13 +97,12 @@
     {% for tag in value.kept_tags %}
         <li>
             <strong><label for="{{ tag.title }}_{{ tag.anidb_tag_id }}">{{ tag.title }}</label></strong>, avec un poids de&nbsp;
-            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;
-            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked />
+            <input type="text" style="max-width: 70px" value="{{ tag.weight }}" id="{{ tag.title }}_{{ tag.anidb_tag_id }}" name="weights" />&nbsp;&nbsp;&nbsp;—
+            <strong><label>Conserver ?&nbsp;&nbsp;<input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag.anidb_tag_id }}" checked /></label></strong>
 
             <input type="hidden" value="{{ tag.title }}" name="tag_titles" />
             <input type="hidden" value="{{ tag.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-            <input type="hidden" value="kept" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -16,86 +16,95 @@
 <form method="post">
 {% csrf_token %}
 
+<p>Veuillez vérifier que les modifications sur les tags vous conviennent, et valider ces modifications.</p>
+<p>Vous pouvez aussi mettre à jour le poids des tags manuellement.</p>
+<p><strong>Liste des œuvres sélectionnées à traiter :</strong>
+    {% for work_id, value in all_information %}
+    <a href="#work_{{ work_id }}">{{ value.title }}</a>{% if not forloop.last %}, {% endif %}
+    {% endfor %}
+</p>
+<hr/><br/>
+
 {% for work_id, value in all_information %}
 
-<h1>(#{{ work_id }}) {{ value.title }}</h1>
+<h1 id="work_{{ work_id }}">(<a href="#work_{{ work_id }}">#{{ work_id }}</a>) {{ value.title }}</h1>
 
+{% if value.deleted_tags %}
 <div>
 <p style="color: red;"><strong>Tags supprimés&nbsp;:</strong></p>
-{% if value.deleted_tags %}
+    <ul>
     {% for tag_title, tag_infos in value.deleted_tags %}
-        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+        <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-        </p>
+        </li>
     {% endfor %}
-{% else %}
-    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été supprimé.</p>
-{% endif %}
+    </ul>
 </div>
+{% endif %}
 
+{% if value.added_tags %}
 <div>
 <p style="color: green;"><strong>Tags ajoutés&nbsp;:</strong></p>
-{% if value.added_tags %}
+    <ul>
     {% for tag_title, tag_infos in value.added_tags %}
-        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+        <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-        </p>
+        </li>
     {% endfor %}
-{% else %}
-    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été ajouté.</p>
-{% endif %}
+    </ul>
 </div>
+{% endif %}
 
+{% if value.updated_tags %}
 <div>
 <p style="color: orange;"><strong>Tags modifiés&nbsp;:</strong></p>
-{% if value.updated_tags %}
+    <ul>
     {% for tag_title, tag_infos in value.updated_tags %}
-        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+        <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}">{{ tag_title }}</label></strong>, dont le poids passe de {{ tag_infos.0.weight }} à&nbsp;
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.1.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-        </p>
+        </li>
     {% endfor %}
-{% else %}
-    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été modifié.</p>
-{% endif %}
+    </ul>
 </div>
+{% endif %}
 
+{% if value.kept_tags %}
 <div>
 <p><strong>Tags conservés&nbsp;:</strong></p>
-{% if value.kept_tags %}
+    <ul>
     {% for tag_title, tag_infos in value.kept_tags %}
-        <p>&nbsp;&nbsp;&nbsp;&nbsp;
+        <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
-        </p>
+        </li>
     {% endfor %}
-{% else %}
-    <p>&nbsp;&nbsp;&nbsp;&nbsp;Aucun tag n'a été conservé.</p>
-{% endif %}
+    </ul>
 </div>
+{% endif %}
+
+<p><strong><label>Mettre à jour les tags de cette œuvre ?&nbsp;&nbsp;<input type="checkbox" name="to_update_work_ids" value="{{ work_id }}" /> </label></strong></p>
+
+<hr/><br/>
 
 {% endfor %}
 
-<p>Quelles sont les œuvres dont vous souhaitez mettre les tags à jour ?</p>
+<p><strong>Êtes-vous certains de vos choix (et éventuelles modifications sur les poids) ?</strong></p>
 <div>
-    {% for work_id, value in all_information %}
-    <p><label><input type="checkbox" name="to_update_work_ids" value="{{ work_id }}" /> {{ value.title }} </label></p>
-    {% endfor %}
-
     {% for obj in queryset %}
     <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
     {% endfor %}

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -36,6 +36,13 @@
     {% for tag_title, tag_infos in value.deleted_tags %}
         <li>
             <strong>{{ tag_title }}</strong>, avec un poids de {{ tag_infos.weight }}&nbsp;
+            <input type="hidden" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
+            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
+            <input type="hidden" value="{{ work_id }}" name="work_ids" />
+            <input type="hidden" value="deleted" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -49,10 +56,13 @@
     {% for tag_title, tag_infos in value.added_tags %}
         <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+
+            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
+            <input type="hidden" value="added" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -66,10 +76,13 @@
     {% for tag_title, tag_infos in value.updated_tags %}
         <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}">{{ tag_title }}</label></strong>, dont le poids passe de {{ tag_infos.0.weight }} à&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />&nbsp;
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.1.anidb_tag_id }}" checked />
+
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.1.weight }}" id="{{ tag_title }}_{{ tag_infos.1.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.1.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
+            <input type="hidden" value="modified" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>
@@ -83,10 +96,13 @@
     {% for tag_title, tag_infos in value.kept_tags %}
         <li>
             <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
+            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />&nbsp;
+            <input type="checkbox" name="tag_checkboxes" value="{{ work_id }}:{{ tag_infos.anidb_tag_id }}" checked />
+
             <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
             <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
             <input type="hidden" value="{{ work_id }}" name="work_ids" />
+            <input type="hidden" value="kept" name="tag_operations" />
         </li>
     {% endfor %}
     </ul>

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -109,7 +109,7 @@
 </div>
 {% endif %}
 
-<p><strong><label>Mettre à jour les tags de cette œuvre ?&nbsp;&nbsp;<input type="checkbox" name="to_update_work_ids" value="{{ work_id }}" /> </label></strong></p>
+<p style="color: red;"><strong><label>Mettre à jour les tags de cette œuvre ?&nbsp;&nbsp;<input type="checkbox" name="to_update_work_ids" value="{{ work_id }}" /> </label></strong></p>
 
 <hr/><br/>
 

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -20,12 +20,15 @@
 <p>Vous pouvez aussi mettre à jour le poids des tags manuellement.</p>
 <p><strong>Liste des œuvres sélectionnées à traiter :</strong>
     {% for work_id, value in all_information %}
+    {% if value.deleted_tags or value.added_tags or value.updated_tags or value.kept_tags %}
     <a href="#work_{{ work_id }}">{{ value.title }}</a>{% if not forloop.last %}, {% endif %}
+    {% endif %}
     {% endfor %}
 </p>
 <hr/><br/>
 
 {% for work_id, value in all_information %}
+{% if value.deleted_tags or value.added_tags or value.updated_tags or value.kept_tags %}
 
 <h1 id="work_{{ work_id }}">(<a href="#work_{{ work_id }}">#{{ work_id }}</a>) {{ value.title }}</h1>
 
@@ -113,6 +116,7 @@
 
 <hr/><br/>
 
+{% endif %}
 {% endfor %}
 
 <p><strong>Êtes-vous certains de vos choix (et éventuelles modifications sur les poids) ?</strong></p>

--- a/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
+++ b/mangaki/mangaki/templates/admin/update_tags_via_anidb.html
@@ -35,11 +35,7 @@
     <ul>
     {% for tag_title, tag_infos in value.deleted_tags %}
         <li>
-            <strong><label for="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}">{{ tag_title }}</label></strong>, avec un poids de&nbsp;
-            <input type="hidden" value="{{ tag_title }}" name="tag_titles" />
-            <input type="text" style="max-width: 70px" value="{{ tag_infos.weight }}" id="{{ tag_title }}_{{ tag_infos.anidb_tag_id }}" name="weights" />
-            <input type="hidden" value="{{ tag_infos.anidb_tag_id }}" name="anidb_tag_ids" />
-            <input type="hidden" value="{{ work_id }}" name="work_ids" />
+            <strong>{{ tag_title }}</strong>, avec un poids de {{ tag_infos.weight }}&nbsp;
         </li>
     {% endfor %}
     </ul>

--- a/mangaki/mangaki/tests/test_anidb.py
+++ b/mangaki/mangaki/tests/test_anidb.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from mangaki.models import Category, Editor, Studio, Work, RelatedWork, Role, Staff, Artist, TaggedWork, Tag
-from mangaki.utils.anidb import to_python_datetime, AniDB
+from mangaki.utils.anidb import to_python_datetime, AniDB, diff_between_anidb_and_local_tags
 
 
 class AniDBTest(TestCase):
@@ -88,7 +88,8 @@ class AniDBTest(TestCase):
                 )
 
             sangatsu = self.anidb.get_or_update_work(11606)
-            retrieved_tags_sangatsu = sangatsu.retrieve_tags(self.anidb)
+            tags_sangatsu_from_anidb = self.anidb.get_tags(11606)
+            tags_diff_sangatsu = diff_between_anidb_and_local_tags(sangatsu, tags_sangatsu_from_anidb)
             hibike = self.anidb.get_or_update_work(10889)
 
         # Retrieve tags
@@ -113,10 +114,10 @@ class AniDBTest(TestCase):
         self.assertCountEqual(staff_sangatsu, ['Umino Chika', 'Hashimoto Yukari', 'Shinbou Akiyuki', 'Okada Kenjirou'])
 
         # Check retrieved tags from AniDB
-        self.assertEqual(len(retrieved_tags_sangatsu["deleted_tags"]), 0)
-        self.assertEqual(len(retrieved_tags_sangatsu["added_tags"]), 0)
-        self.assertEqual(len(retrieved_tags_sangatsu["updated_tags"]), 0)
-        self.assertEqual(len(retrieved_tags_sangatsu["kept_tags"]), len(tags_sangatsu))
+        self.assertEqual(len(tags_diff_sangatsu["deleted_tags"]), 0)
+        self.assertEqual(len(tags_diff_sangatsu["added_tags"]), 0)
+        self.assertEqual(len(tags_diff_sangatsu["updated_tags"]), 0)
+        self.assertEqual(len(tags_diff_sangatsu["kept_tags"]), len(tags_sangatsu))
 
         # Check for no artist duplication
         artist = Artist.objects.filter(name="Shinbou Akiyuki")

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -30,7 +30,7 @@ class RefreshFromAniDBTest(TestCase):
 
     def setUp(self):
         self.user = get_user_model().objects.create_superuser(username='test', password='test', email='email@email.email')
-        
+
         client.client_id = 'fake'
         client.client_ver = 1
         client.is_available = True
@@ -87,6 +87,6 @@ class RefreshFromAniDBTest(TestCase):
         }
 
         response = self.client.post(refresh_tags_from_anidb_url, context)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
         tags = set(Work.objects.get(anidb_aid=10889).taggedwork_set.all().values_list('tag__title', flat=True))

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -77,16 +77,23 @@ class RefreshFromAniDBTest(TestCase):
     def test_refresh_tags_from_anidb_confirmed(self):
         self.add_to_responses('hibike_euphonium.xml')
         self.client.login(username='test', password='test')
+        hibike = Work.objects.get(title='Hibike! Euphonium')
 
         refresh_tags_from_anidb_url = reverse('admin:mangaki_work_changelist')
         context = {
             'action': 'update_tags_via_anidb',
             admin.ACTION_CHECKBOX_NAME: self.work_ids,
-            'post': 1,
-            'checks': [Work.objects.get(title='Hibike! Euphonium').pk]
+            'confirm': 1,
+            'to_update_work_ids': [str(hibike.pk)],
+            'work_ids': [str(hibike.pk), str(hibike.pk), str(hibike.pk)],
+            'tag_titles': ['female protagonist', 'facial distortion', 'training'],
+            'weights': ['0', '0', '400'],
+            'anidb_tag_ids': ['5851', '4055', '3831'],
+            'tag_operations': ['added', 'added', 'added'],
+            'tag_checkboxes': [str(hibike.pk)+':5851', str(hibike.pk)+':4055', str(hibike.pk)+':3831']
         }
 
         response = self.client.post(refresh_tags_from_anidb_url, context)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
         tags = set(Work.objects.get(anidb_aid=10889).taggedwork_set.all().values_list('tag__title', flat=True))

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -503,8 +503,10 @@ client = AniDB(
     getattr(settings, 'ANIDB_VERSION', None)
 )
 
+AniDBTag = Dict[str, Any]
+
 def diff_between_anidb_and_local_tags(work: Work,
-                                      anidb_tags: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Dict[str, Any]]]:
+                                      anidb_tags: Dict[str, AniDBTag]) -> Dict[str, Dict[str, AniDBTag]]:
     """
     Return a Dict containing the difference (ie. added, updated, deleted or kept
     tags) between AniDB's tags and local tags.

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -311,16 +311,12 @@ class AniDB:
     def update_tags(self,
                     work: Work,
                     anidb_tags: List[AniDBTag]):
-        tag_work_list = TaggedWork.objects.filter(work=work).all()
-        values = tag_work_list.values_list('tag__title', 'weight', 'tag__anidb_tag_id')
-        current_tags = [AniDBTag(title=v[0], weight=v[1], anidb_tag_id=v[2]) for v in values]
+        tags_diff = diff_between_anidb_and_local_tags(work, anidb_tags)
 
-        all_tags = current_tags + anidb_tags
-
-        deleted_tags = list(set(current_tags) - set(anidb_tags))
-        added_tags = list(set(anidb_tags) - set(current_tags))
-        kept_tags = list(set.intersection(set(anidb_tags), set(current_tags)))
-        updated_tags = list(set(all_tags) - set(kept_tags))
+        deleted_tags = tags_diff['deleted_tags']
+        added_tags = tags_diff['added_tags']
+        updated_tags = tags_diff['updated_tags']
+        kept_tags = tags_diff['kept_tags']
 
         deleted_tags_titles = [tag.title for tag in deleted_tags]
         added_tags_id = [tag.anidb_tag_id for tag in added_tags]

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -502,3 +502,38 @@ client = AniDB(
     getattr(settings, 'ANIDB_CLIENT', None),
     getattr(settings, 'ANIDB_VERSION', None)
 )
+
+def diff_between_anidb_and_local_tags(work: Work,
+                                      anidb_tags: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """
+    Return a Dict containing the difference (ie. added, updated, deleted or kept
+    tags) between AniDB's tags and local tags.
+    """
+
+    tag_work_list = TaggedWork.objects.filter(work=work).all()
+    values = tag_work_list.values_list('tag__title', 'tag__anidb_tag_id', 'weight')
+    current_tags = {
+        value[0]: {
+            'weight': value[2],
+            'anidb_tag_id': value[1]
+        } for value in values
+    }
+
+    deleted_tags_keys = current_tags.keys() - anidb_tags.keys()
+    deleted_tags = {key: current_tags[key] for key in deleted_tags_keys}
+
+    added_tags_keys = anidb_tags.keys() - current_tags.keys()
+    added_tags = {key: anidb_tags[key] for key in added_tags_keys}
+
+    remaining_tags_keys = list(set(current_tags.keys()).intersection(anidb_tags.keys()))
+    remaining_tags = {key: current_tags[key] for key in remaining_tags_keys}
+
+    updated_tags = {title: (current_tags[title], anidb_tags[title]) for title in remaining_tags if current_tags[title] != anidb_tags[title]}
+    kept_tags = {title: current_tags[title] for title in remaining_tags if current_tags[title] == anidb_tags[title]}
+
+    return {
+        'deleted_tags': deleted_tags,
+        'added_tags': added_tags,
+        'updated_tags': updated_tags,
+        'kept_tags': kept_tags
+    }

--- a/mangaki/mangaki/utils/anidb.py
+++ b/mangaki/mangaki/utils/anidb.py
@@ -304,7 +304,13 @@ class AniDB:
             tag_verified = tag_node.get('verified').lower() == 'true'
 
             if tag_verified:
-                tags.append( AniDBTag(title=tag_title, weight=tag_weight, anidb_tag_id=tag_id) )
+                tags.append(
+                    AniDBTag(
+                        title=tag_title,
+                        weight=tag_weight,
+                        anidb_tag_id=tag_id
+                    )
+                )
 
         return tags
 
@@ -317,8 +323,9 @@ class AniDB:
         added_tags = tags_diff['added_tags']
         updated_tags = tags_diff['updated_tags']
         kept_tags = tags_diff['kept_tags']
+        all_tags = deleted_tags + added_tags + updated_tags + kept_tags
 
-        tags_ids = [tag.anidb_tag_id for tag in deleted_tags+added_tags+updated_tags+kept_tags]
+        tags_ids = [tag.anidb_tag_id for tag in all_tags]
         deleted_tags_ids = [tag.anidb_tag_id for tag in deleted_tags]
 
         existing_tags = Tag.objects.filter(anidb_tag_id__in=tags_ids).all()


### PR DESCRIPTION
Closes #205 by improving the administration page for refreshing AniDB tags :
- Cleaner disposition
- Possibility to **modify the weight of tags** that were modified, added or kept by AniDB
- Possibility to **choose which works should have their tags updated** (after reviewing new tag information from AniDB)
- Possibility to **select which tags should be added, updated, kept or deleted** (by default, the checkboxes are checked meaning the planned operation will happen when submitting, given the work is marked for update)

Also moves the `Work.retrieve_tags` method to `utils/anidb/diff_between_anidb_and_local_tags`.
And no longer calls the API twice in order to only update 1 work !