### PR TITLE
Correctly handle errors when merging works in admin

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -37,8 +37,8 @@ class MergeType(Enum):
 
 
 def overwrite_fields(final_work, request):
-    fields_to_choose = set(request.POST.get('fields_to_choose').split(','))
-    fields_required = set(request.POST.get('fields_required').split(','))
+    fields_to_choose = set(filter(None, request.POST.get('fields_to_choose').split(',')))
+    fields_required = set(filter(None, request.POST.get('fields_required').split(',')))
     missing_required_fields = []
 
     for field in fields_to_choose:

--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -37,10 +37,20 @@ class MergeType(Enum):
 
 
 def overwrite_fields(final_work, request):
-    for field in request.POST.get('fields_to_choose').split(','):
-        if request.POST.get(field) != 'None':
-            setattr(final_work, field, request.POST.get(field))
-    final_work.save()
+    fields_to_choose = set(request.POST.get('fields_to_choose').split(','))
+    fields_required = set(request.POST.get('fields_required').split(','))
+    missing_required_fields = []
+
+    for field in fields_to_choose:
+        curr_field = request.POST.get(field)
+        if curr_field != 'None' and curr_field is not None:
+            setattr(final_work, field, curr_field)
+        if (curr_field == 'None' or curr_field is None) and field in fields_required:
+            missing_required_fields.append(field)
+
+    if not missing_required_fields:
+        final_work.save()
+    return missing_required_fields  # Return the list of missing required fields
 
 
 def redirect_ratings(works_to_merge, final_work):
@@ -93,7 +103,9 @@ def create_merge_form(works_to_merge_qs):
     for work_dict in work_dicts_to_merge:
         for field in work_dict:
             rows[field].append(work_dict[field])
+
     fields_to_choose = []
+    fields_required = []
     template_rows = []
     for field in rows:
         choices = rows[field]
@@ -117,10 +129,13 @@ def create_merge_form(works_to_merge_qs):
         })
         if field != 'id' and merge_type != MergeType.INFO_ONLY:
             fields_to_choose.append(field)
+        if merge_type == MergeType.CHOICE_REQUIRED:
+            fields_required.append(field)
+
     template_rows.sort(key=lambda row: row['merge_type'].priority, reverse=True)
     rating_samples = [(Rating.objects.filter(work_id=work_dict['id']).count(),
                        Rating.objects.filter(work_id=work_dict['id'])[:10]) for work_dict in work_dicts_to_merge]
-    return fields_to_choose, template_rows, rating_samples
+    return fields_to_choose, fields_required, template_rows, rating_samples
 
 
 @transaction.atomic  # In case trouble happens
@@ -134,14 +149,26 @@ def merge_works(request, selected_queryset):
         from_cluster = False
         works_to_merge_qs = selected_queryset.prefetch_related('rating_set', 'genre')
         works_to_merge = list(works_to_merge_qs)
+
     if request.POST.get('confirm'):  # Merge has been confirmed
         if not from_cluster:
             cluster = WorkCluster(user=request.user, checker=request.user)
             cluster.save()  # Otherwise we cannot add works
             cluster.works.add(*works_to_merge)
+
+        # Happens when no ID was provided
+        if not request.POST.get('id'):
+            return None, None, 'no ID'
+
         final_id = int(request.POST.get('id'))
         final_work = Work.objects.get(id=final_id)
-        overwrite_fields(final_work, request)
+
+        missing_required_fields = overwrite_fields(final_work, request)
+
+        # Happens when a required field was left empty
+        if missing_required_fields:
+            return None, missing_required_fields, 'fields missing'
+
         redirect_ratings(works_to_merge, final_work)
         redirect_staff(works_to_merge, final_work)
         redirect_related_objects(works_to_merge, final_work)
@@ -149,9 +176,14 @@ def merge_works(request, selected_queryset):
             checker=request.user, resulting_work=final_work, merged_on=timezone.now(), status='accepted')
         return len(works_to_merge), final_work, None
 
-    fields_to_choose, template_rows, rating_samples = create_merge_form(works_to_merge_qs)
+    # Just show a warning if only one work was checked
+    if len(works_to_merge) < 2:
+        return None, None, 'not enough works checked'
+
+    fields_to_choose, fields_required, template_rows, rating_samples = create_merge_form(works_to_merge_qs)
     context = {
         'fields_to_choose': ','.join(fields_to_choose),
+        'fields_required': ','.join(fields_required),
         'template_rows': template_rows,
         'rating_samples': rating_samples,
         'queryset': selected_queryset,
@@ -358,6 +390,19 @@ class WorkAdmin(admin.ModelAdmin):
 
     def merge(self, request, queryset):
         nb_merged, final_work, response = merge_works(request, queryset)
+        if response == 'no ID':
+            self.message_user(request,
+                              "Aucun ID n'a été fourni pour la fusion.",
+                              level=messages.ERROR)
+        if response == 'fields missing':
+            self.message_user(request,
+                              """Un ou plusieurs des champs requis n'ont pas été remplis.
+                              (Détails: {})""".format(", ".join(final_work)),
+                              level=messages.ERROR)
+        if response == 'not enough works checked':
+            self.message_user(request,
+                              "Veuillez sélectionner au moins 2 œuvres à fusionner.",
+                              level=messages.WARNING)
         if response is None:  # Confirmed
             self.message_user(request, format_html('La fusion de {:d} œuvres vers <a href="{:s}">{:s}</a> a bien été effectuée.'
                 .format(nb_merged, final_work.get_absolute_url(), final_work.title)))

--- a/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
+++ b/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
@@ -19,9 +19,9 @@
 <table>
 {% for row in template_rows %}
     <tr>
-        <th><span style="color: {{ row.color }}">{{ row.field }}</span></th>
+        <th style="vertical-align: middle;"><span style="color: {{ row.color }}">{{ row.field }}</span></th>
         {% for choice in row.choices %}
-            <td>
+            <td style="max-width: 450px;">
                 <label>
                     {% if row.merge_type != 'INFO_ONLY' %}
                         {% comment %}
@@ -30,7 +30,7 @@
                         <input type="radio" name="{{ row.field }}" value="{{ choice|safe }}" {% if choice == row.suggested %} checked{% endif %} />
                     {% endif %}
                     {% if row.field == 'ext_poster' %}
-                        <img src="{{ choice }}" alt="{{ choice }}" />
+                        <img src="{{ choice }}" alt="{{ choice }}" style="max-height: 300px;" />
                     {% elif row.field == 'source' %}
                         <a href="{{ choice }}">{{ choice }}</a>
                     {% else %}
@@ -59,6 +59,7 @@
     <input type="hidden" name="action" value="{{ action }}" />
     <input type="hidden" name="confirm" value="yes" />
     <input type="hidden" name="fields_to_choose" value="{{ fields_to_choose }}" />
+    <input type="hidden" name="fields_required" value="{{ fields_required }}" />
     <input type="submit" value="{% trans "Yes, I'm sure" %}" />
     <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
 </div>

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -75,7 +75,8 @@ class MergeTest(TestCase):
             admin.ACTION_CHECKBOX_NAME: self.work_ids,
             'confirm': 1,
             'id': self.work_ids[0],  # Chosen ID for the canonical work
-            'fields_to_choose': ''
+            'fields_to_choose': '',
+            'fields_required': ''
         }
         with self.assertNumQueries(36):
             self.client.post(merge_url, context)


### PR DESCRIPTION
Closes #419 by correctly handling errors when merging works (ie. missing destination ID or missing required fields) instead of showing a 500 error page !