### PR TITLE
HTML is not escaped in Work's synopsis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ media
 .hypothesis
 # Merci JJ <3
 /mangaki/debug.log
+# Configuration de Visual Studio Code
+.vscode/

--- a/mangaki/mangaki/static/js/vote.js
+++ b/mangaki/mangaki/static/js/vote.js
@@ -108,7 +108,7 @@ Card.prototype.hydrate = function (work) {
   $el.find('.work-card__media').css('background-image', 'url("' + work.poster + '")');
   $el.find('.work-card__title').text(work.title);
   $el.find('.work-cover__wrapper').attr('data-category', work.category);
-  $el.find('.work-card__synopsis').text(work.synopsis);
+  $el.find('.work-card__synopsis').html(work.synopsis);
   $el.find('.work-card__link').attr('href', '/' + this.category + '/' + work.id);
   $el.find('.ratings .rating__checkbox').attr('name', 'rating[' + work.id + ']').each(function () {
     this.checked = false;

--- a/mangaki/mangaki/templates/mangaki/work_rating.html
+++ b/mangaki/mangaki/templates/mangaki/work_rating.html
@@ -16,7 +16,7 @@
             <div class="work-cover__content">
             <div class="work-card__content">
                 <div class="work-card__synopsis">
-                    {{ work.synopsis|linebreaksbr }}
+                    {{ work.synopsis | safe | linebreaksbr}}
                 </div>
                 <a href="{% if work.id == None %}#{% else %}{% url "work-detail" work.category.slug work.id %}{% endif %}"
                         class="work-card__link">


### PR DESCRIPTION
Le good first issue est un peu exagéré ici :)

Réussi à faire la modif dans work_rating.hml (cf la branche liée), ce qui fonctionne dans le cas hors mosaïque de recommandation.

Par contre n'étant que ultra débutant en Python j'ai du mal à voir où rajouter un mark_safe() sur le synopsis dans le cas d'une mosaïque de recommandation où les cartes sont chargées via l'API JS et via card.py, si vous avez des pistes je suis preneur ;)

Reference : #453 