### PR TITLE
Celery re-introduction for Vagrant with instructions!

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -21,6 +21,7 @@ Prérequis
 
 - 3.4 ≤ Python ≥ 3.6
 - 9.3 ≤ PostgreSQL ≤ 10
+- 4.0.0 ≤ Redis ≤ 4.0.2
 
 Si vous n'avez jamais fait de Django, je vous renvoie vers [leur super tutoriel](https://docs.djangoproject.com/en/1.9/intro/tutorial01/).
 
@@ -65,10 +66,15 @@ l'application. Pour une installation de développement, il suffit de faire :
     cat > mangaki/settings.ini <<EOF
     [debug]
     DEBUG = True
+    DEBUG_VUE_JS = True
 
     [secrets]
     SECRET_KEY = $(pwgen -s -c 60 1)
     DB_PASSWORD = ${DB_PASSWORD}
+
+    [celery]
+    BROKER_URL = redis://
+    RESULT_BACKEND = redis://
 
     [email]
     EMAIL_BACKEND = django.core.mail.backends.console.EmailBackend

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Requires Python 3.4 → 3.6, PostgreSQL 9.3 → 10, Redis 4.0, and preferably `p
 
 This step is mandatory only if you need background tasks which is required for features such as MAL imports.
 
-     celery -A -B mangaki:celery_app worker -l INFO
+     # Ensure that your working directory is where manage.py is. (i.e. ls in this folder should show you manage.py)
+     celery -B -A mangaki:celery_app worker -l INFO
 
 If you can read something along these lines:
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Requires [Vagrant](https://www.vagrantup.com/downloads.html).
 
     vagrant up
     vagrant provision  # May be required
-    vagrant ssh  # Will open a tmux that you can detach using C-b d
+    vagrant ssh  # Will open a tmux that you can detach by pressing Ctrl + b then d
 
 And voilà! You can access Mangaki at http://192.168.33.10:8000 (or http://app.mangaki.dev if you have `vagrant-hostupdater`).
 
 ### Full install
 
-Requires Python 3.4 → 3.6, PostgreSQL 9.3 → 10, and preferably `pwgen`.
+Requires Python 3.4 → 3.6, PostgreSQL 9.3 → 10, Redis 4.0, and preferably `pwgen`.
 
     ./config.sh
     python3 -m venv venv
@@ -29,6 +29,23 @@ Requires Python 3.4 → 3.6, PostgreSQL 9.3 → 10, and preferably `pwgen`.
     pip install -r requirements/dev.txt
     cd mangaki
     ./manage.py migrate
+
+#### Running the background worker (Celery)
+
+This step is mandatory only if you need background tasks which is required for features such as MAL imports.
+
+     celery -A -B mangaki:celery_app worker -l INFO
+
+If you can read something along these lines:
+
+```console
+[2017-10-29 14:34:47,810: INFO/MainProcess] celery@your_hostname ready.
+```
+
+The worker is ready to receive background tasks (e.g. MAL imports).
+
+#### Running the web server
+
     ./manage.py runserver
 
 And voilà! You can access Mangaki at http://localhost:8000.

--- a/config.sh
+++ b/config.sh
@@ -14,10 +14,15 @@ psql -d mangaki -c \
 cat > mangaki/settings.ini <<EOF
 [debug]
 DEBUG = True
+DEBUG_VUE_JS = True
 
 [secrets]
 SECRET_KEY = $(pwgen -s -c 60 1)
 DB_PASSWORD = ${DB_PASSWORD}
+
+[celery]
+BROKER_URL = redis://
+RESULT_BACKEND = redis://
 
 [email]
 EMAIL_BACKEND = django.core.mail.backends.console.EmailBackend

--- a/provisioning/group_vars/mangaki_dev
+++ b/provisioning/group_vars/mangaki_dev
@@ -3,6 +3,7 @@ mangaki_source_db_host: '127.0.0.1'
 mangaki_source_db_user: '{{ mangaki_db_user }}'
 mangaki_source_db_name: '{{ mangaki_db_name }}'
 mangaki_source_db_password: '{{ mangaki_db_password }}'
+mangaki_source_redis_password: '{{ mangaki_redis_password }}'
 mangaki_source_static_root: '{{ mangaki_source_home }}/www/static'
 mangaki_source_domains: ['mangaki.dev', '192.168.33.10']  # VM IP
 

--- a/provisioning/roles/mangaki_source/defaults/main.yml
+++ b/provisioning/roles/mangaki_source/defaults/main.yml
@@ -21,7 +21,7 @@ mangaki_source_db_user: '{{ mangaki_db_user }}'
 mangaki_source_redis_host: '127.0.0.1'
 mangaki_source_redis_port: 6379
 mangaki_source_redis_database: 0
-mangaki_source_redis_password: '{{ mangaki_redis_password | default("") }}'
+mangaki_source_redis_password: '{{ mangaki_redis_password }}'
 
 # Email
 mangaki_source_has_email: true

--- a/provisioning/roles/mangaki_source/tasks/main.yml
+++ b/provisioning/roles/mangaki_source/tasks/main.yml
@@ -17,7 +17,9 @@
     name: '{{ item }}'
     state: 'latest'
   with_items:
+    - 'build-essential'
     - 'python3'
+    - 'python3-dev'
     - 'python3-virtualenv'
     - 'virtualenv'
   become: true
@@ -113,7 +115,7 @@
       if [ $? -ne 0 ]; then
       tmux new-session -d -c {{ mangaki_source_package }} -n "Django" -s {{ mangaki_source_name }} '{{ mangaki_source_manage }} runserver 0.0.0.0:8000' 2> /dev/null || true
         tmux set-option -t {{ mangaki_source_name }} set-remain-on-exit on
-        # tmux new-window -c {{ mangaki_source_package }} -n "Celery" -t {{ mangaki_source_name }} '{{ mangaki_source_venv_path }}/bin/celery -A mangaki:celery_app worker -l INFO' 2>/dev/null || true
+        tmux new-window -c {{ mangaki_source_package }} -n "Celery" -t {{ mangaki_source_name }} '{{ mangaki_source_venv_path }}/bin/celery -A mangaki:celery_app worker -l INFO' 2>/dev/null || true
         tmux attach-session -t {{ mangaki_source_name }}
       fi
       echo "Development server is running on port 8000; attach with 'tmux attach -t {{ mangaki_source_name }}'"

--- a/provisioning/roles/utils/redis/handlers/main.yml
+++ b/provisioning/roles/utils/redis/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart redis.
   service:
-    name: 'redis'
+    name: 'redis-server'
     state: 'restarted'
   become: true

--- a/provisioning/roles/utils/redis/tasks/main.yml
+++ b/provisioning/roles/utils/redis/tasks/main.yml
@@ -17,8 +17,8 @@
   template:
     src: 'etc/redis/redis.conf'
     dest: '/etc/redis/redis.conf'
-    owner: 'root'
-    group: 'root'
+    owner: 'redis'
+    group: 'redis'
     mode: '0640'
   become: true
   notify: Restart redis.
@@ -27,8 +27,8 @@
   template:
     src: 'etc/redis/core.conf'
     dest: '/etc/redis/core.conf'
-    owner: 'root'
-    group: 'root'
+    owner: 'redis'
+    group: 'redis'
     mode: '0644'
   become: true
   notify: Restart redis.


### PR DESCRIPTION
As #498 lands on master, we should be able to use Celery for Vagrant powered instances.