### PR TITLE
Add auto-fix, re-open, close buttons to Mangaki Fix

### DIFF
--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -464,7 +464,7 @@ class Suggestion(models.Model):
         It'll raise ValueError when it is impossible to automatically fix the issue.
         """
         if self.problem in ('nsfw', 'n_nsfw'):
-            self.work.nsfw = not self.work.nsfw
+            self.work.nsfw = True if self.problem == 'nsfw' else False
             self.work.save()
         else:
             raise ValueError('Unable to auto-fix `{}`-type suggestions.'.format(self.problem))

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -11,7 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.search import SearchVectorField
 from django.core.files import File
 from django.core.urlresolvers import reverse
-from django.db import models
+from django.db import models, transaction
 from django.db.models import CharField, F, Func, Lookup, Value, Q, FloatField, ExpressionWrapper
 from django.db.models.functions import Cast
 from django.utils.functional import cached_property
@@ -449,6 +449,28 @@ class Suggestion(models.Model):
         return 'Suggestion#{} de {} : {} - {}'.format(
             self.pk, self.user, self.work.title, self.get_problem_display()
         )
+
+    @property
+    def can_auto_fix(self):
+        # FIXME: use Enum + dynamic based on evidences / message (links).
+        return self.problem in ('nsfw', 'n_nsfw')
+
+    @transaction.atomic
+    def auto_fix(self):
+        """
+        Apply automatically a fix on the issue.
+        e.g. for a NSFW (resp. non-NSFW) problem, it'll set the work as NSFW (resp. non-NSFW).
+
+        It'll raise ValueError when it is impossible to automatically fix the issue.
+        """
+        if self.problem in ('nsfw', 'n_nsfw'):
+            self.work.nsfw = not self.work.nsfw
+            self.work.save()
+        else:
+            raise ValueError('Unable to auto-fix `{}`-type suggestions.'.format(self.problem))
+
+        self.is_checked = True
+        self.save()
 
 
 class Evidence(models.Model):

--- a/mangaki/mangaki/templates/fix/fix_suggestion.html
+++ b/mangaki/mangaki/templates/fix/fix_suggestion.html
@@ -94,6 +94,19 @@
                     </span>
                 </p>
                 {% if evidence %}
+                    {% if evidence.agrees and can_auto_fix %}
+                        <p align="center">
+                            <button type="submit" class="btn btn-xs btn-primary" value="True" name="auto_fix">
+                                Résoudre automatiquement le problème
+                            </button>
+                        </p>
+                    {% elif not evidence.agrees and can_close %}
+                        <p align="center">
+                            <button type="submit" class="btn btn-xs btn-default" value="True" name="close_suggestion">
+                                Fermer cette suggestion
+                            </button>
+                        </p>
+                    {% endif %}
                 <p align="center">
                     {% if not evidence.needs_help %}
                     <button type="submit" class="btn btn-xs btn-primary" value="True" name="needs_help">Demander l'aide d'un administrateur</button>
@@ -114,6 +127,17 @@
                 Vous avez <strong><span class="text-danger">rejeté <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span></span></strong> cette suggestion.
                 {% endif %}
             </p>
+            <form id="evidence_form" action="{% url "update-evidence" %}?next={{ request.get_full_path }}" method="POST">
+                {% csrf_token %}
+                <input type="hidden" name="suggestion" value="{{ suggestion.pk }}" />
+                <p align="center">
+                    {% if can_reopen %}
+                        <button type="submit" class="btn btn-primary" name="re_open" value="True">
+                            Réouvrir cette suggestion
+                        </button>
+                    {% endif %}
+                </p>
+            </form>
             {% if evidence.needs_help %}
             <p align="center">
                 Vous avez demandé <strong>l'aide d'un administrateur</strong>.


### PR DESCRIPTION
Auto-fix is available only for NSFW/non-NSFW issues for now.

I am still thinking about the semantics of closing / re-opening a suggestion, if you auto fix a suggestion, then re-open it, what does it mean? The issue is already fixed, right?