### PR TITLE
Automatic Work Cluster from exact title match

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -6,11 +6,9 @@ from django.contrib import messages
 from django.contrib.admin import helpers
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.db.models import Count, Case, When, Value, IntegerField
-from django.db.models.aggregates import Max
+from django.db.models import Count
 from django.template.response import TemplateResponse
 from django.utils.html import format_html, format_html_join
-from django.utils import timezone
 
 from mangaki.models import (
     Work, TaggedWork, WorkTitle, Genre, Track, Tag, Artist, Studio, Editor, Rating, Page,

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -133,7 +133,8 @@ class Work(models.Model):
     ext_poster = models.CharField(max_length=128, db_index=True)
     int_poster = models.FileField(upload_to='posters/', blank=True, null=True)
     nsfw = models.BooleanField(default=False)
-    date = models.DateField(blank=True, null=True) # Should be renamed to start_date
+    # Should be renamed to start_date
+    date = models.DateField(blank=True, null=True)
     end_date = models.DateField(blank=True, null=True)
     synopsis = models.TextField(blank=True, default='')
     ext_synopsis = models.TextField(blank=True, default='')

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -500,7 +500,7 @@ class WorkCluster(models.Model):
     origin = models.ForeignKey(Suggestion, related_name='origin_suggestion', on_delete=models.CASCADE, blank=True, null=True)
 
     def __str__(self):
-        return 'WorkCluster %s' % '-'.join([str(work.id) for work in self.works.all()])
+        return 'WorkCluster ({})'.format(', '.join(self.works))
 
 
 class Announcement(models.Model):

--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -68,7 +68,8 @@ INSTALLED_APPS = (
     'allauth.socialaccount',
     'bootstrap3',
     'django_js_reverse',
-    'rest_framework'
+    'rest_framework',
+    'django_celery_beat'
 )
 
 if config.has_section('sentry'):

--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -237,7 +237,7 @@ REST_FRAMEWORK = {
 REDIS_URL = config.get('celery', 'broker_url', fallback='redis://')
 CELERY_BROKER_URL = config.get('celery', 'broker_url', fallback='redis://')
 CELERY_RESULT_BACKEND = config.get('celery', 'result_backend', fallback='redis://')
-CELERYBEAT_SCHEDULER = config.get('celery', 'scheduler', fallback='django_celery_beat.schedulers:DatabaseScheduler')
+CELERY_BEAT_SCHEDULER = config.get('celery', 'scheduler', fallback='django_celery_beat.schedulers:DatabaseScheduler')
 
 EMAIL_BACKEND = config.get('email', 'EMAIL_BACKEND', fallback='django.core.mail.backends.smtp.EmailBackend')
 if config.has_section('smtp'):

--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -237,6 +237,7 @@ REST_FRAMEWORK = {
 REDIS_URL = config.get('celery', 'broker_url', fallback='redis://')
 CELERY_BROKER_URL = config.get('celery', 'broker_url', fallback='redis://')
 CELERY_RESULT_BACKEND = config.get('celery', 'result_backend', fallback='redis://')
+CELERYBEAT_SCHEDULER = config.get('celery', 'scheduler', fallback='django_celery_beat.schedulers:DatabaseScheduler')
 
 EMAIL_BACKEND = config.get('email', 'EMAIL_BACKEND', fallback='django.core.mail.backends.smtp.EmailBackend')
 if config.has_section('smtp'):

--- a/mangaki/mangaki/tasks.py
+++ b/mangaki/mangaki/tasks.py
@@ -66,8 +66,6 @@ def look_for_workclusters(steal_workcluster: bool = False):
         logger.info('Compression done.')
 
 
-
-
 @app.task(name='import_mal', bind=True, ignore_result=True)
 def import_mal(self, mal_username: str, mangaki_username: str):
     r = redis.StrictRedis(connection_pool=redis_pool)

--- a/mangaki/mangaki/tasks.py
+++ b/mangaki/mangaki/tasks.py
@@ -4,13 +4,16 @@ import json
 import redis
 from celery.utils.log import get_task_logger
 from django.db import IntegrityError
+from django.db.models import Count, Q
 
+from mangaki.utils.work_merge import create_work_cluster, merge_work_clusters
 from .celery import app
 from django.contrib.auth.models import User
 from django.conf import settings
 
-from mangaki.models import UserBackgroundTask
+from mangaki.models import UserBackgroundTask, Work, WorkCluster
 import mangaki.utils.mal as mal
+import redis_lock
 
 MAL_IMPORT_TAG = 'MAL_IMPORT'
 
@@ -29,6 +32,40 @@ else:
 
 def get_current_mal_import(user: User):
     return user.background_tasks.filter(tag=MAL_IMPORT_TAG).first()
+
+# 10 minutes.
+
+DEFAULT_LOCK_EXPIRATION_TIME = 10*60
+
+
+@app.task(name='look_for_workclusters', ignore_result=True)
+def look_for_workclusters(steal_workcluster: bool = False):
+    logger.info('Looking for easy WorkCluster to create...')
+    with redis_lock.Lock(redis.StrictRedis(connection_pool=redis_pool),
+                         'lock-wc-lookout',
+                         expire=DEFAULT_LOCK_EXPIRATION_TIME):
+        logger.info('Acquired Redis lock.')
+        # MAL-created duplicates
+        duplicates = Work.objects.values('title').annotate(Count('id')).filter(id__count__gte=2)
+        for dupe in duplicates.iterator():
+            works = Work.objects.filter(title=dupe['title']).prefetch_related('workcluster_set')
+            cluster = create_work_cluster(works)
+            logger.info('Clustered {} works. ({})'.format(len(works), cluster.id))
+
+        logger.info('Clustering done.')
+        logger.info('Compresssing redundant work clusters.')
+        for work in Work.objects.prefetch_related('workcluster_set').iterator():
+            # Only merge automatic unprocessed work clusters.
+            cluster_filter = Q(status='unprocessed')
+            if not steal_workcluster:
+                cluster_filter |= Q(user=None)
+            clusters = work.workcluster_set.filter(cluster_filter).order_by('id').all()
+            if len(clusters) > 1:
+                merge_work_clusters(*clusters)
+                logger.info('{} clusters merged.'.format(len(clusters)))
+        logger.info('Compression done.')
+
+
 
 
 @app.task(name='import_mal', bind=True, ignore_result=True)

--- a/mangaki/mangaki/tasks.py
+++ b/mangaki/mangaki/tasks.py
@@ -46,7 +46,7 @@ def look_for_workclusters(steal_workcluster: bool = False):
                          expire=DEFAULT_LOCK_EXPIRATION_TIME):
         logger.info('Acquired Redis lock.')
         # MAL-created duplicates
-        duplicates = Work.objects.values('title').annotate(Count('id')).filter(id__count__gte=2)
+        duplicates = Work.objects.values('title', 'category_id').annotate(Count('id')).filter(id__count__gte=2)
         for dupe in duplicates.iterator():
             works = Work.objects.filter(title=dupe['title']).prefetch_related('workcluster_set')
             cluster = create_work_cluster(works)

--- a/mangaki/mangaki/tasks.py
+++ b/mangaki/mangaki/tasks.py
@@ -33,13 +33,26 @@ else:
 def get_current_mal_import(user: User):
     return user.background_tasks.filter(tag=MAL_IMPORT_TAG).first()
 
-# 10 minutes.
 
+# 10 minutes.
 DEFAULT_LOCK_EXPIRATION_TIME = 10*60
 
 
 @app.task(name='look_for_workclusters', ignore_result=True)
 def look_for_workclusters(steal_workcluster: bool = False):
+    """
+    A maintenance Celery Task which clusters works in the database,
+    creating WorkCluster objects.
+
+    Args:
+        steal_workcluster (bool): Allow for this task to merge non-automatic WorkClusters with automatic ones.
+            (i.e. if a WorkCluster is deemed to be the same but its user is human,
+            we would steal or not its WorkCluster to merge it with a new one).
+
+    Returns: None.
+
+    """
+
     logger.info('Looking for easy WorkCluster to create...')
     with redis_lock.Lock(redis.StrictRedis(connection_pool=redis_pool),
                          'lock-wc-lookout',
@@ -57,7 +70,7 @@ def look_for_workclusters(steal_workcluster: bool = False):
         for work in Work.objects.prefetch_related('workcluster_set').iterator():
             # Only merge automatic unprocessed work clusters.
             cluster_filter = Q(status='unprocessed')
-            if not steal_workcluster:
+            if not steal_workcluster:  # Don't be evil. Don't steal human WorkClusters.
                 cluster_filter |= Q(user=None)
             clusters = work.workcluster_set.filter(cluster_filter).order_by('id').all()
             if len(clusters) > 1:

--- a/mangaki/mangaki/tasks.py
+++ b/mangaki/mangaki/tasks.py
@@ -66,7 +66,7 @@ def look_for_workclusters(steal_workcluster: bool = False):
             logger.info('Clustered {} works. ({})'.format(len(works), cluster.id))
 
         logger.info('Clustering done.')
-        logger.info('Compresssing redundant work clusters.')
+        logger.info('Compressing redundant work clusters.')
         for work in Work.objects.prefetch_related('workcluster_set').iterator():
             # Only merge automatic unprocessed work clusters.
             cluster_filter = Q(status='unprocessed')

--- a/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
+++ b/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
@@ -23,7 +23,7 @@
         {% for choice in row.choices %}
             <td style="max-width: 450px;">
                 <label>
-                    {% if row.merge_type != 'INFO_ONLY' %}
+                    {% if row.action_type != 'DO_NOTHING' %}
                         <input type="radio" name="{{ row.field }}"
                                value="{% if row.field == 'date' or row.field == 'end_date' %}{{ choice|date:'Y-m-d' }}{% else %}{{ choice }}{% endif %}"
                                {% if choice == row.suggested %} checked{% endif %} />

--- a/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
+++ b/mangaki/mangaki/templates/admin/merge_selected_confirmation.html
@@ -30,6 +30,12 @@
                     {% endif %}
                     {% if row.field == 'ext_poster' %}
                         <img src="{{ choice }}" alt="{{ choice }}" style="max-height: 300px;" />
+                    {% elif row.field == 'int_poster' %}
+                        {% if choice.size %}
+                            <img src="{{ choice.url }}" alt="{{ choice.name }} - {{ choice.size }}" style="max-height: 300px;" />
+                        {% else %}
+                            Rien n'est stocké sur le disque.
+                        {% endif %}
                     {% elif row.field == 'source' %}
                         <a href="{{ choice }}">{{ choice }}</a>
                     {% else %}

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 from django.db import connection
-from mangaki.models import Work, Editor, Category, Studio, WorkCluster, Rating, Staff, Role, Artist, Genre
+from mangaki.models import Work, Editor, Category, Studio, WorkCluster, Rating, Staff, Role, Artist, Genre, Reference
 from datetime import datetime, timedelta
 
 
@@ -26,6 +26,15 @@ class MergeTest(TestCase):
         Rating.objects.bulk_create([Rating(work_id=work_id, user=self.user, choice='like') for work_id in self.work_ids])
 
         the_artist = Artist.objects.create(name='Yoko Kanno')
+
+        references = []
+        for work_id in self.work_ids:
+            references.extend(Reference.objects.bulk_create([
+                Reference(work_id=work_id, source='MAL', identifier=31646,
+                          url='https://myanimelist.net/anime/31646'),
+                Reference(work_id=work_id, source='AniDB', identifier=11606,
+                          url='https://anidb.net/perl-bin/animedb.pl?show=anime&aid=11606')
+            ]))
 
         roles = Role.objects.bulk_create([
             Role(name='Director', slug='xxx'),

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -87,10 +87,11 @@ class MergeTest(TestCase):
             'fields_to_choose': '',
             'fields_required': ''
         }
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(39):
             self.client.post(merge_url, context)
         self.assertEqual(list(Rating.objects.filter(user__in=self.users).values_list('choice', flat=True)), ['favorite'] * 4)
         self.assertEqual(Work.all_objects.filter(redirect__isnull=True).count(), 1)
         self.assertEqual(WorkCluster.objects.count(), 1)
         self.assertEqual(Staff.objects.count(), 2)
+        self.assertEqual(Reference.objects.count(), 2)
         self.assertEqual(Work.objects.get(id=self.work_ids[0]).genre.count(), 2)

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -4,10 +4,9 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
-from django.db import connection
 
 from mangaki import tasks
-from mangaki.models import Work, Editor, Category, Studio, WorkCluster, Rating, Staff, Role, Artist, Genre, Reference
+from mangaki.models import Work, Category, WorkCluster, Rating, Staff, Role, Artist, Genre, Reference
 from datetime import datetime, timedelta
 
 from mangaki.utils.work_merge import create_work_cluster, merge_work_clusters
@@ -79,13 +78,13 @@ class MergeTest(TestCase):
         Rating.objects.filter(work_id=self.work_ids[2], user=self.users[2]).update(date=yesterday),
         Rating.objects.filter(work_id=self.work_ids[0], user=self.users[3]).update(date=yesterday)
 
-    def test_merge(self, **kwargs):
+    def test_merge(self):
         self.client.login(username='test', password='test')
         merge_url = reverse('admin:mangaki_work_changelist')
         response = self.client.post(merge_url, {'action': 'merge', admin.ACTION_CHECKBOX_NAME: self.work_ids})
         self.assertEqual(response.status_code, 200)
 
-    def test_merge_confirmed(self, **kwargs):
+    def test_merge_confirmed(self):
         self.client.login(username='test', password='test')
         merge_url = reverse('admin:mangaki_work_changelist')
         context = {

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -26,7 +26,10 @@ class MergeTest(TestCase):
         tomorrow = datetime.now() + timedelta(1)
 
         anime = Category.objects.get(slug='anime')
+
         Work.objects.bulk_create([Work(title='Sangatsu no Lion', category=anime) for _ in range(10)])
+        Work.objects.create(title='Sangatsu no Lion', category=anime, nb_episodes=22)
+
         self.work_ids = Work.objects.values_list('id', flat=True)
         # Admin rated every movie
         Rating.objects.bulk_create([Rating(work_id=work_id, user=self.user, choice='like') for work_id in self.work_ids])

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -105,6 +105,7 @@ class MergeTest(TestCase):
         self.assertEqual(Work.objects.get(id=self.work_ids[0]).genre.count(), 2)
 
     # noinspection PyPep8Naming
+    # FIXME: classical scenario, we should have a simpler decorator to perform those tests
     @patch('redis.StrictRedis', autospec=True, create=True)
     @patch('redis_lock.Lock', autospec=True, create=True)
     def test_look_for_workcluster_deduplication_task(self, Lock, _):

--- a/mangaki/mangaki/utils/mal.py
+++ b/mangaki/mangaki/utils/mal.py
@@ -26,8 +26,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-MATCH_ONLY_OVER_REFERENCED_WORKS = True
-
 
 # MAL provides three fields related to titles:
 #   — `english_title` which is, by definition, in english.

--- a/mangaki/mangaki/utils/mal.py
+++ b/mangaki/mangaki/utils/mal.py
@@ -26,6 +26,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+MATCH_ONLY_OVER_REFERENCED_WORKS = True
+
 
 # MAL provides three fields related to titles:
 #   — `english_title` which is, by definition, in english.

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -21,6 +21,24 @@ from mangaki.models import (
 
 
 def is_param_null(param):
+    """
+    Test if a parameter in a request is null (i.e. 'None' or None or falsy).
+
+    Args:
+        param (Any): a value parameter
+
+    Returns: True if null, False otherwise.
+
+    >>> is_param_null('None')
+    True
+    >>> is_param_null(None)
+    True
+    >>> is_param_null('')
+    True
+    >>> is_param_null('Inconnu')
+    False
+
+    """
     return param == 'None' or (not param) or param is None
 
 
@@ -28,6 +46,24 @@ UNK_VALUES = {'Inconnu', ''}
 
 
 def is_empty_field(field):
+    """
+    Test if a work field is empty, i.e. None or value in default unknown values.
+
+    Args:
+        field (Any): value of the field
+
+    Returns: True if empty, False otherwise.
+
+    >>> is_empty_field('Inconnu')
+    True
+    >>> is_empty_field('')
+    True
+    >>> is_empty_field(None)
+    True
+    >>> is_empty_field('anime')
+    False
+
+    """
     return field is None or field in UNK_VALUES
 
 
@@ -156,6 +192,19 @@ class WorkClusterMergeHandler:
 
     def merge_references(self):
         def compute_hash(source, identifier):
+            """
+            Compute an hash for a given reference (source, identifier) couple.
+
+            Args:
+                source (str): Source of the reference (e.g. MAL, AniDB)
+                identifier (Any): Unique identifier for the given source (e.g. ID)
+                    which can be converted into a string through str.
+
+            Returns: A string digest
+
+            >>> hash('MAL', 1)
+            4255228164310404961
+            """
             return hash(source + str(identifier))
 
         references = Reference.objects.filter(work__in=self.works_to_merge).all()

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -14,7 +14,7 @@ def union_work_cluster(cluster, works):
 
 
 def create_work_cluster(works):
-    # Union-Find approach.
+    # FIXME: Do an actual Union-Find.
     target_cluster = None
     for work in works:
         clusters = list(work.workcluster_set.all())

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -1,4 +1,114 @@
-from mangaki.models import WorkCluster
+from django.db.models import Max, Case, When, Value, IntegerField, timezone
+
+from mangaki.models import (
+    WorkCluster,
+    Rating,
+    Staff,
+    TaggedWork,
+    Trope,
+    Recommendation,
+    Suggestion,
+    Pairing,
+    Reference,
+    ColdStartRating,
+    WorkTitle,
+    Work
+)
+
+
+def is_param_null(param):
+    return param == 'None' or param is None
+
+
+class WorkClusterMergeHandler:
+
+    def __init__(self, cluster: WorkCluster, works_to_merge, target_work):
+        self.cluster = cluster
+        self.works_to_merge = works_to_merge
+        self.target_work = target_work
+
+    def accept_cluster(self, checker):
+        WorkCluster.objects.filter(id=self.cluster.id).update(
+            checker=checker,
+            resulting_work=self.target_work,
+            merged_on=timezone.now(),
+            status='accepted')
+
+    def overwrite_fields(self,
+                         fields_to_choose,
+                         fields_required,
+                         new_params):
+        missing_required_fields = []
+
+        for field in fields_to_choose:
+            cur_field = new_params.get(field)
+
+            if not is_param_null(cur_field):
+                setattr(self.target_work, field, cur_field)
+
+            if is_param_null(cur_field) and field in fields_required:
+                missing_required_fields.append(field)
+
+        if not missing_required_fields:
+            self.target_work.save()
+
+        return missing_required_fields
+
+    def perform_redirections(self):
+        self.redirect_ratings()
+        self.redirect_staff()
+        self.redirect_related_objects()
+
+    def redirect_ratings(self):
+        # Get all IDs of considered ratings
+        get_id_of_rating = {}
+        for rating_id, user_id, date in Rating.objects.filter(work__in=self.works_to_merge).values_list('id', 'user_id',
+                                                                                                        'date'):
+            get_id_of_rating[(user_id, date)] = rating_id
+        # What is the latest rating of every user? (N. B. – latest may be null)
+        kept_rating_ids = []
+        latest_ratings = (Rating.objects.filter(
+            work__in=self.works_to_merge
+        ).values('user_id').annotate(latest=Max('date')))
+        for rating in latest_ratings:
+            user_id = rating['user_id']
+            date = rating['latest']
+            kept_rating_ids.append(get_id_of_rating[(user_id, date)])
+        Rating.objects.filter(work__in=self.works_to_merge).exclude(id__in=kept_rating_ids).delete()
+        Rating.objects.filter(id__in=kept_rating_ids).update(work_id=self.target_work.id)
+
+    def redirect_staff(self):
+        self.target_work_staff = set()
+        kept_staff_ids = []
+        # Only one query: put self.target_work's Staff objects first in the list
+        queryset = (Staff.objects.filter(work__in=self.works_to_merge)
+            .annotate(belongs_to_target_work=Case(
+                When(work_id=self.target_work.id, then=Value(1)),
+                     default=Value(0), output_field=IntegerField()))
+            .order_by('-belongs_to_target_work')
+            .values_list('id', 'work_id', 'artist_id', 'role_id'))
+        for staff_id, work_id, artist_id, role_id in queryset:
+            if work_id == self.target_work.id:  # This condition will be met for the first iterations
+                self.target_work_staff.add((artist_id, role_id))
+            # Now we are sure we know every staff of the final work
+            elif (artist_id, role_id) not in self.target_work_staff:
+                kept_staff_ids.append(staff_id)
+        Staff.objects.filter(work__in=self.works_to_merge).exclude(work_id=self.target_work.id).exclude(
+            id__in=kept_staff_ids).delete()
+        Staff.objects.filter(id__in=kept_staff_ids).update(work_id=self.target_work.id)
+
+    def redirect_related_objects(self):
+        genres = sum((list(work.genre.all()) for work in self.works_to_merge), [])
+        work_ids = [work.id for work in self.works_to_merge]
+        existing_tag_ids = TaggedWork.objects.filter(work=self.target_work).values_list('tag__pk', flat=True)
+
+        self.target_work.genre.add(*genres)
+        Trope.objects.filter(origin_id__in=work_ids).update(origin_id=self.target_work.id)
+        TaggedWork.objects.filter(work_id__in=work_ids).exclude(tag_id__in=existing_tag_ids).update(
+            work_id=self.target_work.id)
+        for model in [WorkTitle, Suggestion, Recommendation, Pairing, Reference, ColdStartRating]:
+            model.objects.filter(work_id__in=work_ids).update(work_id=self.target_work.id)
+        Work.objects.filter(id__in=work_ids).exclude(id=self.target_work.id).update(redirect=self.target_work)
 
 
 def merge_work_clusters(*clusters):

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -37,6 +37,7 @@ PRECOMPUTED_FIELDS = {'sum_ratings',
                       'nb_dislikes',
                       'controversy',
                       'title_search',
+                      'int_poster',
                       'redirect_id'}
 
 

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -24,7 +24,7 @@ def is_param_null(param):
     return param == 'None' or (not param) or param is None
 
 
-UNK_VALUES = {'Inconnu'}
+UNK_VALUES = {'Inconnu', ''}
 
 
 def is_empty_field(field):

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -1,0 +1,30 @@
+from mangaki.models import WorkCluster
+
+
+def merge_work_clusters(*clusters):
+    target_cluster = clusters[0]
+    for cluster in clusters[1:]:
+        union_work_cluster(target_cluster, list(cluster.works.all()))
+        cluster.delete()
+    return target_cluster
+
+
+def union_work_cluster(cluster, works):
+    cluster.works.add(*works)
+
+
+def create_work_cluster(works):
+    # Union-Find approach.
+    target_cluster = None
+    for work in works:
+        clusters = list(work.workcluster_set.all())
+        if clusters:
+            target_cluster = clusters[0]
+            break
+
+    if not target_cluster:
+        target_cluster = WorkCluster.objects.create()
+
+    union_work_cluster(target_cluster, works)
+
+    return target_cluster

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from enum import IntEnum
 from typing import List
 
-from django.db.models import Max, Case, When, Value, IntegerField, QuerySet
+from django.db.models import Max, Case, When, Value, IntegerField
 from django.utils import timezone
 
 from mangaki.models import (

--- a/mangaki/setup.py
+++ b/mangaki/setup.py
@@ -30,6 +30,8 @@ setup(
         'coreapi>=2.3,<3',
         'celery>=4.2,<5',
         'redis>=2.10,<3',
+        'python-redis-lock>=3.2,<4',
+        'django-celery-beat>=1.1,<2',
         'Pillow>=4.1,<5',
         'setuptools_scm>=1.15,<2',
         'django-sendfile>=0.3,<1'

--- a/provisioning/roles/mangaki_source/tasks/main.yml
+++ b/provisioning/roles/mangaki_source/tasks/main.yml
@@ -115,7 +115,7 @@
       if [ $? -ne 0 ]; then
       tmux new-session -d -c {{ mangaki_source_package }} -n "Django" -s {{ mangaki_source_name }} '{{ mangaki_source_manage }} runserver 0.0.0.0:8000' 2> /dev/null || true
         tmux set-option -t {{ mangaki_source_name }} set-remain-on-exit on
-        tmux new-window -c {{ mangaki_source_package }} -n "Celery" -t {{ mangaki_source_name }} '{{ mangaki_source_venv_path }}/bin/celery -A mangaki:celery_app worker -l INFO' 2>/dev/null || true
+        tmux new-window -c {{ mangaki_source_package }} -n "Celery" -t {{ mangaki_source_name }} '{{ mangaki_source_venv_path }}/bin/celery -B -A mangaki:celery_app worker -l INFO' 2>/dev/null || true
         tmux attach-session -t {{ mangaki_source_name }}
       fi
       echo "Development server is running on port 8000; attach with 'tmux attach -t {{ mangaki_source_name }}'"

--- a/provisioning/roles/utils/celery/README.md
+++ b/provisioning/roles/utils/celery/README.md
@@ -30,6 +30,9 @@ celery_autoscale_max: 10
 # Additional environment for the Celery program, as a dictionary
 celery_env: {}
 
+# Enable the beat scheduler
+celery_beat: true
+
 # Start Celery through supervisorctl (default: true)
 start: true
 ```

--- a/provisioning/roles/utils/celery/defaults/main.yml
+++ b/provisioning/roles/utils/celery/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 celery_env: {}
+celery_beat_name: '{{ celery_name }}-beat'
 celery_autoscale_min: 3
 celery_autoscale_max: 10
 celery_log_level: 'INFO'
+celery_beat: false
 start: true

--- a/provisioning/roles/utils/celery/tasks/main.yml
+++ b/provisioning/roles/utils/celery/tasks/main.yml
@@ -20,3 +20,10 @@
     state: present
   become: true
   when: start
+
+- name: Run Celery beat.
+  supervisorctl:
+    name: '{{ celery_beat_name }}'
+    state: present
+  become: true
+  when: celery_beat

--- a/provisioning/roles/utils/celery/templates/etc/supervisor/conf.d/celery.conf.j2
+++ b/provisioning/roles/utils/celery/templates/etc/supervisor/conf.d/celery.conf.j2
@@ -5,6 +5,13 @@ command = {{ celery_venv_path }}/bin/celery worker -A {{ celery_app_module }}:{{
 user = {{ celery_user }}
 environment = {% for key, value in celery_env.items() %}{{ key }}="{{ value }}",{% endfor %}
 
+{% if celery_beat %}
+[program:{{ celery_beat_name }}]
+command = {{ celery_venv_path }}/bin/celery beat -A {{ celery_app_module }}:{{ celery_app_name }} --loglevel={{ celery_log_level }}
+user = {{ celery_user }}
+environment = {% for key, value in celery_env.items() %} {{ key }}="{{ value }}", {% endfor %}
+{% endif %}
+
 ; Need to wait for currently executing tasks to finish at shutdown.
 stopwaitsecs = 600
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,8 +17,10 @@ lxml==3.6.*
 raven==6.1.*
 djangorestframework==3.6.*
 coreapi==2.3.*
-celery>=4.2
+celery==4.0.*
+django-celery-beat==1.1.*
 redis==2.10.*
+python-redis-lock==3.2.*
 Pillow>=4.1
 dedupe==1.7.*
 setuptools-scm==1.15.*


### PR DESCRIPTION
- [x] Create Work Clusters from exact title match duplicates ;
- [x] Compression and merge of machine-created clusters ;
- [x] Fixes and improvements to work merge logic (fix #529), also it is now independent of administration, lives in `work_merge.py` utilities as a full-fledged merge handler ;
- [x] Add Celery Beat in Ansible workflow.
- [x] Add Celery Beat in Vagrant workflow.
- [x] Document how to use Celery Beat.
- [x] Write tests for the `WorkMerge` utilities.
- [x] Write tests for the `look_for_workcluster` task.

This PR introduces Celery Beat, a task scheduler which needs initial data migration (which are provided through `manage.py migrate`) and requires to run the beat worker of Celery. Finally, you have to go to the admin panel and configure the periodicity of `look_for_workclusters` (for debugging and instance-specific purpose).

~Depends on #533.~