### PR TITLE
Ensure Work objects after search filter have distinct ID

### DIFF
--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -317,9 +317,9 @@ class WorkList(WorkListMixin, ListView):
             raise Http404
 
         if search_text:
-            self.queryset = self.queryset.filter(Q(title__icontains=search_text) | Q(worktitle__title__icontains=search_text))
+            self.queryset = self.queryset.filter(Q(title__icontains=search_text) | Q(worktitle__title__icontains=search_text)).distinct('id', 'nb_ratings')  # https://stackoverflow.com/questions/20582966/django-order-by-filter-with-distinct
 
-        self.queryset = self.queryset.only('pk', 'title', 'int_poster', 'ext_poster', 'nsfw', 'synopsis', 'category__slug')
+        self.queryset = self.queryset.only('id', 'title', 'int_poster', 'ext_poster', 'nsfw', 'synopsis', 'category__slug')
 
         return self.queryset
 


### PR DESCRIPTION
Search filters were providing pairs `(Work, WorkTitle)`, so duplicates.

In order to avoid the SQL error `SELECT DISTINCT ON expressions must match initial ORDER BY expressions`, `distinct` contains both `id` and `nb_ratings`, in order to order by popularity.

Fixes #574.