### PR TITLE
Compute difficulty of WorkCluster

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -519,7 +519,7 @@ class TaggedWorkAdmin(admin.ModelAdmin):
 
 @admin.register(WorkCluster)
 class WorkClusterAdmin(admin.ModelAdmin):
-    list_display = ('user', 'get_work_titles', 'resulting_work', 'reported_on', 'merged_on', 'checker', 'status', 'get_difficulty')
+    list_display = ('user', 'get_work_titles', 'resulting_work', 'reported_on', 'merged_on', 'checker', 'status', 'difficulty')
     list_filter = ('status',)
     list_select_related = ('user', 'resulting_work', 'checker')
     raw_id_fields = ('user', 'works', 'checker', 'resulting_work')
@@ -546,13 +546,6 @@ class WorkClusterAdmin(admin.ModelAdmin):
         self.message_user(request, "Le rejet de %s a été réalisé avec succès." % message_bit)
 
     reject.short_description = "Rejeter les clusters sélectionnés"
-
-    def get_difficulty(self, obj):
-        works_to_merge_qs = obj.works.order_by('id').prefetch_related('rating_set', 'genre')
-        work_dicts_to_merge = list(works_to_merge_qs.values())
-        field_changeset = get_field_changeset(work_dicts_to_merge)
-        difficulty = sum(data[4] for data in field_changeset)
-        return difficulty
 
     def get_work_titles(self, obj):
         cluster_works = obj.works.all()  # Does not include redirected works

--- a/mangaki/mangaki/management/commands/merge.py
+++ b/mangaki/mangaki/management/commands/merge.py
@@ -1,0 +1,30 @@
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from mangaki.models import Rating, Work, WorkCluster
+from mangaki.admin import merge_works
+
+
+class Command(BaseCommand):
+    args = ''
+    help = 'Merge workclusters'
+
+    def add_arguments(self, parser):
+        parser.add_argument('nb', nargs=1, type=str)
+
+    def handle(self, *args, **options):
+        nb_clusters = int(options.get('nb')[0])
+
+        clusters = WorkCluster.objects.order_by('-id').filter(status='unprocessed')#.annotate(Count('rating')).order_by('-rating__count')[0]
+        self.stdout.write('%d WorkClusters' % (clusters.count()))
+
+        c = 0
+        for cluster in clusters:
+            if cluster.get_difficulty() < 1:
+                merge_works(None, WorkCluster.objects.filter(id=cluster.id), force=True)
+                c += 1
+                self.stdout.write(self.style.SUCCESS('%s was merged' % str(cluster)))
+                if c == nb_clusters:
+                    break

--- a/mangaki/mangaki/management/commands/merge.py
+++ b/mangaki/mangaki/management/commands/merge.py
@@ -17,12 +17,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         nb_clusters = int(options.get('nb')[0])
 
-        clusters = WorkCluster.objects.order_by('-id').filter(status='unprocessed')#.annotate(Count('rating')).order_by('-rating__count')[0]
+        clusters = WorkCluster.objects.order_by('-id').filter(status='unprocessed')
         self.stdout.write('%d WorkClusters' % (clusters.count()))
 
         c = 0
         for cluster in clusters:
-            if cluster.get_difficulty() < 1:
+            if cluster.difficulty < 1:
                 merge_works(None, WorkCluster.objects.filter(id=cluster.id), force=True)
                 c += 1
                 self.stdout.write(self.style.SUCCESS('%s was merged' % str(cluster)))

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -591,7 +591,8 @@ class WorkCluster(models.Model):
     merged_on = models.DateTimeField(blank=True, null=True)
     origin = models.ForeignKey(Suggestion, related_name='origin_suggestion', on_delete=models.CASCADE, blank=True, null=True)
 
-    def get_difficulty(self):
+    @cached_property
+    def difficulty(self):
         works_to_merge_qs = self.works.order_by('id').prefetch_related('rating_set', 'genre')
         work_dicts_to_merge = list(works_to_merge_qs.values())
         field_changeset = get_field_changeset(work_dicts_to_merge)

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 import os.path
 import tempfile
+from enum import IntEnum
 from urllib.parse import urlparse
+from collections import defaultdict
 
 import requests
 from django.conf import settings
@@ -489,6 +491,92 @@ class Evidence(models.Model):
             self.suggestion.pk
         )
 
+UNK_VALUES = {'Inconnu', ''}
+
+def not_empty_field(field):
+    """
+    Test if a work field is not empty, i.e. None or value in default unknown values.
+
+    Args:
+        field (Any): value of the field
+
+    Returns: False if empty, True otherwise.
+
+    >>> not_empty_field('Inconnu')
+    False
+    >>> not_empty_field('')
+    False
+    >>> not_empty_field(None)
+    False
+    >>> not_empty_field('anime')
+    True
+
+    """
+    return field is not None and field not in UNK_VALUES
+
+PRECOMPUTED_FIELDS = {'sum_ratings',
+                      'nb_ratings',
+                      'nb_likes',
+                      'nb_dislikes',
+                      'controversy',
+                      'title_search',
+                      'redirect_id'}
+
+class ActionType(IntEnum):
+    DO_NOTHING = 0
+    JUST_CONFIRM = 1
+    CHOICE_REQUIRED = 2
+
+def scan_workcluster(works_to_merge_qs):
+    work_dicts_to_merge = list(works_to_merge_qs.values())
+    return get_field_changeset(work_dicts_to_merge)
+
+def get_field_changeset(works):
+    rows = defaultdict(list)
+    for work in works:
+        for field in work:
+            rows[field].append(work[field])
+
+    # strip_protocol = re.compile(r'https?://')
+    for field, choices in rows.items():
+        difficulty = 0
+        suggested = None
+
+        filtered_choices = list(set(filter(not_empty_field, choices)))
+
+        if field == 'id':
+            action = ActionType.JUST_CONFIRM
+            suggested = min(int(choice) for choice in choices)
+        elif field in PRECOMPUTED_FIELDS:
+            action = ActionType.DO_NOTHING
+        # All mostly None
+        elif len(filtered_choices) == 0:
+            action = ActionType.JUST_CONFIRM
+            suggested = 'Inconnu' if 'Inconnu' in choices else None
+        # Only one choice if we remove all empty choices
+        elif len(filtered_choices) == 1:
+            action = ActionType.JUST_CONFIRM
+            suggested = filtered_choices[0]
+        # elif field == 'ext_poster' and all(strip_protocol.sub('', choice) == strip_protocol.sub('', choices[0]) for choice in choices):
+        #     difficulty = 0.1
+        #     action = ActionType.JUST_CONFIRM
+        #     suggested = 'https://' + strip_protocol.sub('', choices[0])  # HTTPS has priority
+        elif field == 'ext_poster':
+            difficulty = 0.5
+            action = ActionType.JUST_CONFIRM
+            suggested = filtered_choices[-1]
+        elif field == 'source':
+            difficulty = 100
+            action = ActionType.CHOICE_REQUIRED
+        elif field == 'date':
+            difficulty = 1000
+            action = ActionType.CHOICE_REQUIRED
+        else:
+            difficulty = 1
+            action = ActionType.CHOICE_REQUIRED
+
+        yield (field, choices, action, suggested, difficulty)
+
 
 class WorkCluster(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
@@ -500,8 +588,14 @@ class WorkCluster(models.Model):
     merged_on = models.DateTimeField(blank=True, null=True)
     origin = models.ForeignKey(Suggestion, related_name='origin_suggestion', on_delete=models.CASCADE, blank=True, null=True)
 
+    def get_difficulty(self):
+        works_to_merge_qs = self.works.order_by('id').prefetch_related('rating_set', 'genre')
+        field_changeset = scan_workcluster(works_to_merge_qs)
+        difficulty = sum(data[4] for data in field_changeset)
+        return difficulty
+
     def __str__(self):
-        return 'WorkCluster ({})'.format(', '.join(self.works))
+        return 'WorkCluster ({})'.format(', '.join(str(work) for work in self.works.all()))
 
 
 class Announcement(models.Model):

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -95,7 +95,7 @@ class MergeTest(TestCase):
             'fields_to_choose': '',
             'fields_required': ''
         }
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             self.client.post(merge_url, context)
         self.assertEqual(list(Rating.objects.filter(user__in=self.users).values_list('choice', flat=True)), ['favorite'] * 4)
         self.assertEqual(Work.all_objects.filter(redirect__isnull=True).count(), 1)

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -1,5 +1,4 @@
 from typing import List
-import re
 
 from django.db.models import Max, Case, When, Value, IntegerField
 from django.utils import timezone

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-from enum import IntEnum
 from typing import List
 import re
 
@@ -42,92 +40,6 @@ def is_param_null(param):
 
     """
     return param == 'None' or (not param) or param is None
-
-
-UNK_VALUES = {'Inconnu', ''}
-
-
-def is_empty_field(field):
-    """
-    Test if a work field is empty, i.e. None or value in default unknown values.
-
-    Args:
-        field (Any): value of the field
-
-    Returns: True if empty, False otherwise.
-
-    >>> is_empty_field('Inconnu')
-    True
-    >>> is_empty_field('')
-    True
-    >>> is_empty_field(None)
-    True
-    >>> is_empty_field('anime')
-    False
-
-    """
-    return field is None or field in UNK_VALUES
-
-
-PRECOMPUTED_FIELDS = {'sum_ratings',
-                      'nb_ratings',
-                      'nb_likes',
-                      'nb_dislikes',
-                      'controversy',
-                      'title_search',
-                      'redirect_id'}
-
-
-class ActionType(IntEnum):
-    DO_NOTHING = 0
-    JUST_CONFIRM = 1
-    CHOICE_REQUIRED = 2
-
-
-def field_changeset(works):
-    rows = defaultdict(list)
-
-    for work in works:
-        for field in work:
-            rows[field].append(work[field])
-
-    strip_protocol = re.compile(r'https?://')
-    for field, choices in rows.items():
-        difficulty = 0
-        suggested = None
-
-        if field == 'id':
-            action = ActionType.JUST_CONFIRM
-            suggested = min(int(choice) for choice in choices)
-        elif field in PRECOMPUTED_FIELDS:
-            action = ActionType.DO_NOTHING
-        # All mostly None
-        elif all(is_empty_field(choice) for choice in choices):
-            action = ActionType.JUST_CONFIRM
-            suggested = None
-        # Equality on all values.
-        elif all(choice == choices[0] for choice in choices):
-            action = ActionType.JUST_CONFIRM
-            suggested = choices[0]
-        # All but one field empty.
-        elif sum(is_empty_field(choice) for choice in choices) == len(choices) - 1:
-            action = ActionType.JUST_CONFIRM
-            suggested = [choice for choice in choices if not is_empty_field(choice)][0]
-        elif field == 'ext_poster' and all(strip_protocol.sub('', choice) == strip_protocol.sub('', choices[0]) for choice in choices):
-            difficulty = 0.5
-            action = ActionType.JUST_CONFIRM
-            suggested = 'https://' + strip_protocol.sub('', choices[0])  # HTTPS has priority
-        elif field == 'source':
-            difficulty = 100
-            action = ActionType.CHOICE_REQUIRED
-        elif field == 'date':
-            difficulty = 1000
-            action = ActionType.CHOICE_REQUIRED
-        else:
-            difficulty = 1
-            action = ActionType.CHOICE_REQUIRED
-
-        yield (field, choices, action, suggested, difficulty)
 
 
 class WorkClusterMergeHandler:


### PR DESCRIPTION
- [x] Reduce number of queries when selecting a set of ratings for building the merge form
- [x] Refactor (for example, we do not need the ratings to compute the difficulty, but we need it for the merge form)
- [x] Handle the particular cases `anidb_aid`, `editor_id`, `studio_id` are nonzero.