### PR TITLE
Bump Django 2.1.2, remove ColdStartRating

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -4,7 +4,7 @@ import logging
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin import helpers
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import Count
 from django.template.response import TemplateResponse
@@ -14,7 +14,7 @@ from mangaki.models import (
     Work, TaggedWork, WorkTitle, Genre, Track, Tag, Artist, Studio, Editor, Rating, Page,
     Suggestion, Evidence, Announcement, Recommendation, Pairing, Reference, Top, Ranking,
     Role, Staff, FAQTheme,
-    FAQEntry, ColdStartRating, Trope, Language,
+    FAQEntry, Trope, Language,
     ExtLanguage, WorkCluster,
     UserBackgroundTask,
     ActionType,
@@ -712,7 +712,6 @@ admin.site.register(Rating)
 admin.site.register(Page)
 admin.site.register(FAQEntry)
 admin.site.register(Recommendation)
-admin.site.register(ColdStartRating)
 admin.site.register(Trope)
 admin.site.register(Language)
 admin.site.register(ExtLanguage)

--- a/mangaki/mangaki/settings.py
+++ b/mangaki/mangaki/settings.py
@@ -93,7 +93,6 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware'
 )

--- a/mangaki/mangaki/tests/test_change_default_title.py
+++ b/mangaki/mangaki/tests/test_change_default_title.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 from mangaki.models import Work, Category, WorkTitle, Editor, Studio

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch, Mock
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 

--- a/mangaki/mangaki/tests/test_merge.py
+++ b/mangaki/mangaki/tests/test_merge.py
@@ -95,7 +95,7 @@ class MergeTest(TestCase):
             'fields_to_choose': '',
             'fields_required': ''
         }
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(39):
             self.client.post(merge_url, context)
         self.assertEqual(list(Rating.objects.filter(user__in=self.users).values_list('choice', flat=True)), ['favorite'] * 4)
         self.assertEqual(Work.all_objects.filter(redirect__isnull=True).count(), 1)

--- a/mangaki/mangaki/tests/test_rating.py
+++ b/mangaki/mangaki/tests/test_rating.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 
 from mangaki.models import Studio, Category, Rating, Editor, Work

--- a/mangaki/mangaki/tests/test_reco.py
+++ b/mangaki/mangaki/tests/test_reco.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.contrib.auth import get_user_model
 
 from mangaki.models import Category, Work, Rating

--- a/mangaki/mangaki/tests/test_refresh_from_anidb.py
+++ b/mangaki/mangaki/tests/test_refresh_from_anidb.py
@@ -4,7 +4,7 @@ import responses
 from django.conf import settings
 from django.test import TestCase
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 

--- a/mangaki/mangaki/tests/test_research.py
+++ b/mangaki/mangaki/tests/test_research.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 from mangaki.models import Profile
 from mangaki.utils.tokens import compute_token, KYOTO_SALT

--- a/mangaki/mangaki/urls.py
+++ b/mangaki/mangaki/urls.py
@@ -2,6 +2,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
+from django.urls import path
 from django.contrib import admin
 from django_js_reverse.views import urls_js
 
@@ -76,5 +77,5 @@ if DEBUG:  # https://docs.djangoproject.com/en/1.10/howto/static-files/#serving-
     import debug_toolbar
 
     urlpatterns += [
-                       url(r'^__debug__/', include(debug_toolbar.urls)),
+                       path('__debug__/', include(debug_toolbar.urls)),
                    ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/mangaki/mangaki/utils/archive_export.py
+++ b/mangaki/mangaki/utils/archive_export.py
@@ -14,7 +14,6 @@ from mangaki.models import (
     WorkCluster,
     Recommendation,
     Pairing,
-    ColdStartRating,
     UserBackgroundTask,
     UserArchive
 )
@@ -54,7 +53,6 @@ target_models = {
     WorkCluster: export_workclusters,
     Recommendation: ['target_user__username', 'work__title'],
     Pairing: ['date', 'artist__name', 'work__title', 'is_checked'],
-    ColdStartRating: ['work__title', 'choice', 'date'],
     UserBackgroundTask: ['created_on', 'task_id', 'tag'],
     UserArchive: export_archive_records
 }
@@ -70,7 +68,6 @@ target_filenames = {
     WorkCluster: 'work_clusters.csv',
     Recommendation: 'recommendations.csv',
     Pairing: 'pairings.csv',
-    ColdStartRating: 'cold_start_ratings.csv',
     UserBackgroundTask: 'user_background_tasks.csv',
     UserArchive: 'user_archives.csv'
 }

--- a/mangaki/mangaki/utils/recommendations.py
+++ b/mangaki/mangaki/utils/recommendations.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from scipy.sparse import coo_matrix
 
 from mangaki.models import Rating, Work
 from mangaki.utils.fit_algo import fit_algo, get_algo_backup

--- a/mangaki/mangaki/utils/work_merge.py
+++ b/mangaki/mangaki/utils/work_merge.py
@@ -13,7 +13,6 @@ from mangaki.models import (
     Suggestion,
     Pairing,
     Reference,
-    ColdStartRating,
     WorkTitle,
     Work
 )
@@ -170,7 +169,7 @@ class WorkClusterMergeHandler:
         Trope.objects.filter(origin_id__in=work_ids).update(origin_id=self.target_work.id)
         TaggedWork.objects.filter(work_id__in=work_ids).exclude(tag_id__in=existing_tag_ids).update(
             work_id=self.target_work.id)
-        for model in [WorkTitle, Suggestion, Recommendation, Pairing, ColdStartRating]:
+        for model in [WorkTitle, Suggestion, Recommendation, Pairing]:
             model.objects.filter(work_id__in=work_ids).update(work_id=self.target_work.id)
 
         Work.objects.filter(id__in=work_ids).exclude(id=self.target_work.id).update(redirect=self.target_work)

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -987,13 +987,13 @@ def update_evidence(request):
             evidence.save()
 
     next_url = request.GET.get('next')
-    if next_url and is_safe_url(url=next_url, host=request.get_host()):
+    if next_url and is_safe_url(url=next_url, allowed_hosts=request.get_host()):
         return redirect(next_url)
     return redirect('fix-index')
 
 
 def generic_error_view(error, error_code):
-    def error_view(request):
+    def error_view(request, exception=None):
         try:
             trope = Trope.objects.order_by('?').first()
         except DatabaseError:

--- a/mangaki/mangaki/views.py
+++ b/mangaki/mangaki/views.py
@@ -38,7 +38,7 @@ from natsort import natsorted
 from mangaki.choices import TOP_CATEGORY_CHOICES, SORT_MODE_CHOICES
 from mangaki.forms import SuggestionForm
 from mangaki.mixins import AjaxableResponseMixin, JSONResponseMixin
-from mangaki.models import (Artist, Category, ColdStartRating, FAQTheme, Page, Pairing, Profile, Ranking, Rating,
+from mangaki.models import (Artist, Category, FAQTheme, Page, Pairing, Profile, Ranking, Rating,
                             Recommendation, Staff, Suggestion, Evidence, Top, Trope, Work, WorkCluster)
 from mangaki.utils.mal import client
 from mangaki.tasks import import_mal, get_current_mal_import, redis_pool
@@ -393,7 +393,7 @@ def get_profile(request,
         user = get_object_or_404(User.objects.select_related('profile'), username=username)
     else:
         user = request.user
-        is_anonymous = not request.user.is_authenticated()
+        is_anonymous = not request.user.is_authenticated
 
     if is_anonymous or username is None:
         is_shared = True
@@ -437,7 +437,7 @@ def get_profile(request,
 
 def get_profile_preferences(request,
                             username: str = None):
-    if username is None and request.user.is_authenticated():
+    if username is None and request.user.is_authenticated:
         return redirect('profile-preferences', request.user.username, permanent=True)
 
     user, ctx = get_profile(request, username)
@@ -459,7 +459,7 @@ def get_profile_works(request,
                       username: str = None,
                       category: str = None,
                       status: str = None):
-    if username is None and request.user.is_authenticated():
+    if username is None and request.user.is_authenticated:
         return redirect('profile-works', request.user.username, category or 'anime', status or 'seen', permanent=True)
 
     user, ctx = get_profile(request, username)

--- a/mangaki/mangaki/wrappers/anilist.py
+++ b/mangaki/mangaki/wrappers/anilist.py
@@ -795,7 +795,7 @@ def insert_works_into_database_from_anilist(entries: List[AniListEntry],
 
         # Build genres for this Work
         genres = [Genre.objects.get_or_create(title=genre)[0] for genre in entry.genres]
-        work.genre.set(genres, bulk=True, clear=(not created_work))
+        work.genre.set(genres, clear=(not created_work))
 
         # Create WorkTitle entries in the database for this Work
         build_work_titles(work, titles)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r ./production.txt
 # General development
-django-debug-toolbar==1.8
+django-debug-toolbar==1.10.1
 django-extensions
 django-nose
 flake8

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,5 @@
-Django==1.11.*
-django-allauth==0.28
+Django==2.0.8
+django-allauth==0.38.0
 markdown<3  # https://github.com/encode/django-rest-framework/issues/6203
 django-bootstrap4
 psycopg2-binary
@@ -8,12 +8,12 @@ scipy>=1
 pandas
 beautifulsoup4
 natsort
-django-js-reverse
+django-js-reverse==0.8.2
 responses==0.5.1
 jinja2
 lxml==3.6.*
 raven==6.1.*
-djangorestframework==3.6.*
+djangorestframework==3.8.2
 coreapi==2.3.*
 celery>=4.2
 django-celery-beat==1.1.*

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,24 +1,28 @@
-Django==2.0.8
+# Django
+Django==2.1.2
 django-allauth==0.38.0
-markdown<3  # https://github.com/encode/django-rest-framework/issues/6203
 django-bootstrap4
-psycopg2-binary
-numpy>=1.13
-scipy>=1
-pandas
-beautifulsoup4
-natsort
-django-js-reverse==0.8.2
-responses==0.5.1
-jinja2
-lxml==3.6.*
-raven==6.1.*
-djangorestframework==3.8.2
-coreapi==2.3.*
-celery>=4.2
 django-celery-beat==1.1.*
+django-js-reverse==0.8.2
+django-sendfile==0.3.*
+djangorestframework==3.8.2
+psycopg2-binary
+responses==0.5.1
+markdown==3.0.1
+jinja2  # For tokens and newsletter
+# API
+lxml==3.6.*
+beautifulsoup4
+coreapi==2.3.*
+# Tasks
+celery>=4.2
 redis==2.10.*
 python-redis-lock==3.2.*
+raven==6.1.*
+# Version number
 setuptools-scm==1.15.*
-django-sendfile==0.3.*
+# Algo
+numpy>=1.13
+pandas
+natsort  # Used for sorting profile, will be removed
 git+https://github.com/mangaki/zero


### PR DESCRIPTION
- [x] Fix on_delete (now required)
- [x] Remove useless middlewares
- [x] Remove ColdStartRating entirely
- [x] Replace `django.core.resolvers` with `django.urls`
- [x] Fix tests (exceptions are now returned by Django)
- [x] Remove `scipy` from `mangaki` requirements (but it is still needed in `zero`)