### PR TITLE
Reduce number of queries in admin for inline objects

### DIFF
--- a/mangaki/mangaki/admin.py
+++ b/mangaki/mangaki/admin.py
@@ -175,6 +175,10 @@ class TaggedWorkInline(admin.TabularInline):
     model = TaggedWork
     fields = ('work', 'tag', 'weight')
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related('work', 'tag')
+
 
 class StaffInline(admin.TabularInline):
     model = Staff


### PR DESCRIPTION
But : faire de sorte que charger l'anime Goblin Slayer (beaucoup de tags) prenne moins de 8 s et 197 requêtes.
Actuellement : 6 s et 30 requêtes.