### PR TITLE
Put posters back ┬─┬ノ( º _ ºノ)

### DIFF
--- a/mangaki/mangaki/migrations/0096_fix_mal_cdn.py
+++ b/mangaki/mangaki/migrations/0096_fix_mal_cdn.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+FORMER_CDN = 'myanimelist.cdn-dena.com'
+NEW_CDN = 'cdn.myanimelist.net'
+
+
+def fix_mal_cdn(apps, editor):
+    Work = apps.get_model('mangaki', 'Work')
+    db_alias = editor.connection.alias
+    broken_works = list(Work.objects.using(db_alias)
+                        .filter(ext_poster__contains=FORMER_CDN))
+
+    for broken_work in broken_works:
+        broken_work.ext_poster = broken_work.ext_poster.replace(FORMER_CDN, NEW_CDN)
+        broken_work.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('mangaki', '0095_auto_20180826_1148'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_mal_cdn)
+    ]

--- a/mangaki/mangaki/models.py
+++ b/mangaki/mangaki/models.py
@@ -184,7 +184,11 @@ class Work(models.Model):
     def poster_url(self):
         if self.int_poster:
             return self.int_poster.url
-        return self.ext_poster
+        int_path = '/static/img/posters/{}.jpg'.format(self.id)
+        if os.path.isfile(os.path.join('mangaki', 'mangaki', int_path)):
+            return int_path
+        else:
+            return self.ext_poster
 
     def safe_poster(self, user):
         if self.id is None:


### PR DESCRIPTION
Fixes #653.

The migration is actually a reciprocal of [migrations/0071_fix_mal_cdn.py](https://github.com/mangaki/mangaki/blob/master/mangaki/mangaki/migrations/0071_fix_mal_cdn.py).