### PR TITLE
Fix Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
     # For a complete reference, please see the online documentation at
     # https://docs.vagrantup.com.
     #
-    config.vm.box = "debian/contrib-jessie64"
+    config.vm.box = "debian/contrib-buster64"
 
     config.vm.synced_folder ".", "/vagrant"
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+interpreter_python = python3
+
+[ssh_connection]
+pipelining = True

--- a/provisioning/roles/mangaki_source/tasks/main.yml
+++ b/provisioning/roles/mangaki_source/tasks/main.yml
@@ -14,28 +14,29 @@
 
 - name: Ensure python and virtualenv are installed and up-to-date.
   apt:
-    name: '{{ item }}'
+    name:
+      - 'build-essential'
+      - 'python3'
+      - 'python3-dev'
+      - 'python3-virtualenv'
+      - 'python3-pip'
+      - 'python3-setuptools'
+      - 'virtualenv'
+      - 'git'
     state: 'latest'
-  with_items:
-    - 'build-essential'
-    - 'python3'
-    - 'python3-dev'
-    - 'python3-virtualenv'
-    - 'virtualenv'
   become: true
 
 - name: Ensure virtualenv packages are up-to-date.
   pip:
-    name: '{{ item }}'
+    name:
+      - 'pip'
+      - 'setuptools'
+      - 'git+https://github.com/mangaki/zero'
     state: 'latest'
     virtualenv: '{{ mangaki_source_venv_path }}'
     virtualenv_python: 'python3'
   become: true
   become_user: '{{ mangaki_source_user }}'
-  with_items:
-    - 'pip'
-    - 'setuptools'
-    - 'git+https://github.com/mangaki/zero'
 
 - name: Ensure packaged project is present.
   copy:
@@ -55,11 +56,10 @@
 
 - name: Ensure system-wide development dependencies are installed.
   apt:
-    name: '{{ item }}'
+    name: ['git', 'tmux']
     state: 'latest'
   become: true
   when: 'mangaki_source_install_type == "develop"'
-  with_items: ['git', 'tmux']
 
 - name: Ensure debug-mode dependencies are installed.
   pip:

--- a/provisioning/roles/utils/celery/tasks/main.yml
+++ b/provisioning/roles/utils/celery/tasks/main.yml
@@ -18,12 +18,12 @@
   supervisorctl:
     name: '{{ celery_name }}'
     state: present
-  become: true
+  become: true|bool
   when: start
 
 - name: Run Celery beat.
   supervisorctl:
     name: '{{ celery_beat_name }}'
     state: present
-  become: true
+  become: true|bool
   when: celery_beat

--- a/provisioning/roles/utils/postgresql/tasks/main.yml
+++ b/provisioning/roles/utils/postgresql/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
 - name: Ensure PostgreSQL is installed and up-to-date.
   apt:
-    name: '{{ item }}'
+    name:
+      - 'postgresql'
+      - 'postgresql-contrib' # For extensions, e.g. unaccent and pg_trgm
+      - 'python3-psycopg2'    # For management by ansible
     state: 'latest'
-  with_items:
-    - 'postgresql'
-    - 'postgresql-contrib' # For extensions, e.g. unaccent and pg_trgm
-    - 'python3-psycopg2'    # For management by ansible
   become: true
 
 - name: Ensure PostgreSQL is running.


### PR DESCRIPTION
This mostly changes the Ansible configuration to be compatible with Vagrant:

 - Use Debian Buster
 - Enable pipelining in ansible.cfg
   (see https://docs.ansible.com/ansible/latest/user_guide/become.html#risks-of-becoming-an-unprivileged-user )
 - Use python3 for starting ansible on the host (default interpreter_python
   in ansible.cfg)
 - Some cleanup based on Ansible warnings (mostly stop using loops
   for `apt`)