### PR TITLE
Nix: fix deprecation for the Redis module

### DIFF
--- a/nix/modules/mangaki.nix
+++ b/nix/modules/mangaki.nix
@@ -229,6 +229,10 @@ in
         You want this disabled whenever you have an external Redis instance.
       '';
     };
+    # FIXME: rework this to use a redis connection URI
+    # same mechanism as database connection URI
+    # prefer local socket auth
+    # pass the stuff with systemd
     redisConfig = mkOption {
       type = types.nullOr (types.submodule redisOptions);
       default = null;
@@ -307,7 +311,10 @@ in
       inherit (mangakiEnv) MANGAKI_SETTINGS_PATH DJANGO_SETTINGS_MODULE;
     };
 
-    services.redis.enable = cfg.useLocalRedis; # Redis set.
+    services.redis.servers.mangaki = mkIf cfg.useLocalRedis {
+      enable = true;
+    };
+
     services.postgresql = mkIf cfg.useLocalDatabase {
       enable = cfg.useLocalDatabase; # PostgreSQL set.
       ensureUsers = [


### PR DESCRIPTION
- [ ] Support connection URIs in `settings.py` with secret files
- [ ] For local Redis, use socket auth towards the correct instance
- [ ] Fix external configuration in Nix
- [ ] Connect everything and test
